### PR TITLE
volumeSlider updates on running Volume Cue

### DIFF
--- a/lisp/layouts/cart_layout/cue_widget.py
+++ b/lisp/layouts/cart_layout/cue_widget.py
@@ -214,7 +214,7 @@ class CueWidget(QWidget):
     def reset_volume(self):
         if self._volume_element is not None:
             self.volumeSlider.setValue(round(fader_to_slider(
-                self._volume_element.volume) * CueWidget.SLIDER_RANGE))
+                self._volume_element.current_volume) * CueWidget.SLIDER_RANGE))
 
     def _set_cue(self, cue):
         self.cue = cue

--- a/lisp/modules/action_cues/volume_control.py
+++ b/lisp/modules/action_cues/volume_control.py
@@ -106,6 +106,8 @@ class VolumeControl(Cue):
                 time = ntime(self.__time, begin, duration)
                 volume.current_volume = functor(time, volume_diff, base_volume)
 
+                volume.changed('volume').emit()
+
                 self.__time += 1
                 sleep(0.01)
 


### PR DESCRIPTION
The volume slider in CartLayout was not updated by "Volume Cues". When touching the volume fader after a volume cue fade, this caused big a jump of the audio level. 