### PR TITLE
Msc dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For bugs/requests an issue can be open on the GitHub issues-tracker, for everyth
 You can download an [AppImage](http://appimage.org/) bundle of LiSP from the release page, once downloaded make the file executable.
 Now you should be able to run LiSP by double-clicking the file.
 
-Tested on the following systems:
+Tested on the following systems *(it should work on newer versions)*:
  * Debian 8
  * Ubuntu 16.04
  * Fedora 24
@@ -32,6 +32,6 @@ Use the installed launcher from the menu (for the package installation), or
     $ linux-show-player                                  # Launch the program
     $ linux-show-player -l [debug/warning/info]          # Launch with different log options
     $ linux-show-player -f <file/path>                   # Open a saved session
-    $ linux-show-plater --locale <locale>                # Launch using the given locale
+    $ linux-show-player --locale <locale>                # Launch using the given locale
 
 *User documentation downloaded under the GitHub release page or [viewed online](http://linux-show-player-users.readthedocs.io/en/latest/index.html)*

--- a/lisp/modules/action_cues/msc_cue.py
+++ b/lisp/modules/action_cues/msc_cue.py
@@ -2,7 +2,8 @@
 #
 # This file is part of Linux Show Player
 #
-# Copyright 2012-2016 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2017 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2017 Thomas Achtner <info@offtools.de>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,22 +18,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
-import functools
-
 from PyQt5.QtCore import Qt, QT_TRANSLATE_NOOP
-from PyQt5.QtCore import QTime
-from PyQt5.QtWidgets import QGroupBox, QVBoxLayout, QGridLayout, QLabel, \
-    QComboBox, QSpinBox, QDoubleSpinBox, QFrame, QCheckBox, QTimeEdit, QPushButton
+from PyQt5.QtWidgets import QVBoxLayout, QPushButton
 
 from lisp.core.has_properties import Property
 from lisp.cues.cue import Cue
+from lisp.modules.midi.midi_msc import MscArgument, MscStringParser
 from lisp.modules.midi.midi_output import MIDIOutput
+from lisp.ui import elogging
 from lisp.ui.settings.cue_settings import CueSettingsRegistry
 from lisp.ui.settings.settings_page import SettingsPage
+from lisp.ui.widgets.msc_groupbox import MscGroupBox
 from lisp.ui.ui_utils import translate
-from lisp.modules.midi.midi_msc import MscMessage, MscCommand, \
-    MscCommandFormat, MscArgument, MscStringParser, MscTimeType
-from lisp.ui import elogging
 
 
 class MscCue(Cue):
@@ -53,281 +50,6 @@ class MscCue(Cue):
             MIDIOutput().send_from_str(self.message)
 
         return False
-
-
-class MscGroupBox(QGroupBox):
-
-    DATA_WIDGET = 0
-    CHECK_WIDGET = 1
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-
-        self.setLayout(QGridLayout())
-        self.layout().setColumnStretch(0, 10)
-        self.layout().setColumnStretch(1, 10)
-        self.layout().setColumnStretch(2, 1)
-
-        # Device ID
-        self.__mscDeviceLabel = QLabel(self)
-        self.layout().addWidget(self.__mscDeviceLabel, 0, 0)
-        self.__mscDeviceSpin = QSpinBox(self)
-        self.__mscDeviceSpin.setRange(0, 127)
-        self.__mscDeviceSpin.setValue(0)
-        self.__mscDeviceSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscDeviceSpin, 0, 1, 1, 2)
-
-        self.__mscCmdFmtLabel = QLabel(self)
-        self.layout().addWidget(self.__mscCmdFmtLabel, 1, 0)
-        self.__mscCmdFmtCombo = QComboBox(self)
-        self.__mscCmdFmtCombo.addItems([str(i) for i in MscCommandFormat])
-        self.__mscCmdFmtCombo.currentTextChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscCmdFmtCombo, 1, 1, 1, 2)
-
-        self.__mscCommandLabel = QLabel(self)
-        self.layout().addWidget(self.__mscCommandLabel, 2, 0)
-        self.__mscCommandCombo = QComboBox(self)
-        self.__mscCommandCombo.addItems([str(i) for i in MscCommand])
-        self.__mscCommandCombo.currentTextChanged.connect(self.__type_changed)
-        self.__mscCommandCombo.currentTextChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscCommandCombo, 2, 1, 1, 2)
-
-        line = QFrame(self)
-        line.setFrameShape(QFrame.HLine)
-        line.setFrameShadow(QFrame.Sunken)
-        self.layout().addWidget(line, 3, 0, 1, 3)
-
-        # Data widgets
-        self.__data_widgets = {}
-
-        self.__mscQNumberLabel = QLabel(self)
-        self.layout().addWidget(self.__mscQNumberLabel, 4, 0)
-        self.__mscQNumberSpin = QDoubleSpinBox(self)
-        self.__mscQNumberSpin.setRange(0, 999)
-        self.__mscQNumberSpin.setDecimals(3)
-        self.__mscQNumberSpin.setSingleStep(1.0)
-        self.__mscQNumberSpin.setValue(0)
-        self.__mscQNumberSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscQNumberSpin, 4, 1)
-        self.__mscQNumberCheck = QCheckBox(self)
-        self.__mscQNumberCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_NUMBER))
-        self.layout().addWidget(self.__mscQNumberCheck, 4, 2)
-        self.__data_widgets[MscArgument.Q_NUMBER] = [self.__mscQNumberSpin, self.__mscQNumberCheck]
-
-        self.__mscQListLabel = QLabel(self)
-        self.layout().addWidget(self.__mscQListLabel, 5, 0)
-        self.__mscQListSpin = QDoubleSpinBox(self)
-        self.__mscQListSpin.setRange(0, 999)
-        self.__mscQListSpin.setDecimals(3)
-        self.__mscQListSpin.setSingleStep(1.0)
-        self.__mscQListSpin.setValue(0)
-        self.__mscQListSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscQListSpin, 5, 1)
-        self.__mscQListCheck = QCheckBox(self)
-        self.__mscQListCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_LIST))
-        self.layout().addWidget(self.__mscQListCheck, 5, 2)
-        self.__data_widgets[MscArgument.Q_LIST] = [self.__mscQListSpin, self.__mscQListCheck]
-
-        self.__mscQPathLabel = QLabel(self)
-        self.layout().addWidget(self.__mscQPathLabel, 6, 0)
-        self.__mscQPathSpin = QDoubleSpinBox(self)
-        self.__mscQPathSpin.setRange(0, 999)
-        self.__mscQPathSpin.setDecimals(3)
-        self.__mscQPathSpin.setSingleStep(1.0)
-        self.__mscQPathSpin.setValue(0)
-        self.__mscQPathSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscQPathSpin, 6, 1)
-        self.__mscQPathCheck = QCheckBox(self)
-        self.__mscQPathCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_PATH))
-        self.layout().addWidget(self.__mscQPathCheck, 6, 2)
-        self.__data_widgets[MscArgument.Q_PATH] = [self.__mscQPathSpin, self.__mscQPathCheck]
-
-        self.__mscMacroLabel = QLabel(self)
-        self.layout().addWidget(self.__mscMacroLabel, 7, 0)
-        self.__mscMacroSpin = QSpinBox(self)
-        self.__mscMacroSpin.setRange(0, 127)
-        self.__mscMacroSpin.setValue(0)
-        self.__mscMacroSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscMacroSpin, 7, 1)
-        self.__mscMacroCheck = QCheckBox(self)
-        self.__mscMacroCheck.toggled.connect(functools.partial(self.__checked, MscArgument.MACRO_NUM))
-        self.layout().addWidget(self.__mscMacroCheck, 7, 2)
-        self.__data_widgets[MscArgument.MACRO_NUM] = [self.__mscMacroSpin, self.__mscMacroCheck]
-
-        self.__mscCtrlNumLabel = QLabel(self)
-        self.layout().addWidget(self.__mscCtrlNumLabel, 8, 0)
-        self.__mscCtrlNumSpin = QSpinBox(self)
-        self.__mscCtrlNumSpin.setRange(0, 1023)
-        self.__mscCtrlNumSpin.setValue(0)
-        self.__mscCtrlNumSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscCtrlNumSpin, 8, 1)
-        self.__mscCtrlNumCheck = QCheckBox(self)
-        self.__mscCtrlNumCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_NUM))
-        self.layout().addWidget(self.__mscCtrlNumCheck, 8, 2)
-        self.__data_widgets[MscArgument.CTRL_NUM] = [self.__mscCtrlNumSpin, self.__mscCtrlNumCheck]
-
-        self.__mscCtrlValLabel = QLabel(self)
-        self.layout().addWidget(self.__mscCtrlValLabel, 9, 0)
-        self.__mscCtrlValSpin = QSpinBox(self)
-        self.__mscCtrlValSpin.setRange(0, 1023)
-        self.__mscCtrlValSpin.setValue(0)
-        self.__mscCtrlValSpin.valueChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscCtrlValSpin, 9, 1)
-        self.__mscCtrlValCheck = QCheckBox(self)
-        self.__mscCtrlValCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_VALUE))
-        self.layout().addWidget(self.__mscCtrlValCheck, 9, 2)
-        self.__data_widgets[MscArgument.CTRL_VALUE] = [self.__mscCtrlValSpin, self.__mscCtrlValCheck]
-
-        self.__mscTimecodeLabel = QLabel(self)
-        self.layout().addWidget(self.__mscTimecodeLabel, 10, 0)
-        self.__mscTimecodeEdit = QTimeEdit(self)
-        self.__mscTimecodeEdit.setDisplayFormat('HH.mm.ss.zzz')
-        self.__mscTimecodeEdit.timeChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscTimecodeEdit, 10, 1)
-        self.__mscTimecodeCheck = QCheckBox(self)
-        self.__mscTimecodeCheck.toggled.connect(functools.partial(self.__checked, MscArgument.TIMECODE))
-        self.layout().addWidget(self.__mscTimecodeCheck, 10, 2)
-        self.__data_widgets[MscArgument.TIMECODE] = [self.__mscTimecodeEdit, self.__mscTimecodeCheck]
-
-        self.__mscTimeTypeLabel = QLabel(self)
-        self.layout().addWidget(self.__mscTimeTypeLabel, 11, 0)
-        self.__mscTimeTypeCombo = QComboBox(self)
-        self.__mscTimeTypeCombo.addItems([str(i) for i in MscTimeType])
-        self.__mscTimeTypeCombo.setCurrentText(str(MscTimeType.SMPTE))
-        self.__mscTimeTypeCombo.currentTextChanged.connect(self.__show_messsage)
-        self.layout().addWidget(self.__mscTimeTypeCombo, 11, 1)
-        self.__mscTimeTypeCheck = QCheckBox(self)
-        self.__mscTimeTypeCheck .toggled.connect(functools.partial(self.__checked, MscArgument.TIME_TYPE))
-        self.layout().addWidget(self.__mscTimeTypeCheck, 11, 2)
-        self.__data_widgets[MscArgument.TIME_TYPE] = [self.__mscTimeTypeCombo, self.__mscTimeTypeCheck]
-
-        self.__mscPreview = QLabel(self)
-        self.__mscPreview.setStyleSheet('font: bold')
-        self.__mscPreview.setMinimumHeight(50)
-        self.layout().addWidget(self.__mscPreview, 13, 0, 1, 2)
-
-        self.__retranslateUi()
-
-        self.__mscCommandCombo.currentTextChanged.emit(str(MscCommand.GO))
-
-    @property
-    def device_id(self):
-        return self.__mscDeviceSpin.value()
-
-    @device_id.setter
-    def device_id(self, device_id):
-        self.__mscDeviceSpin.setValue(device_id)
-
-    @property
-    def command_format(self):
-        return MscCommandFormat(self.__mscCmdFmtCombo.currentTextChanged())
-
-    @command_format.setter
-    def command_format(self, command_format):
-        self.__mscCmdFmtCombo.setCurrentText(str(command_format))
-
-    @property
-    def command(self):
-        return MscCommand(self.__mscCommandCombo.currentText())
-
-    @command.setter
-    def command(self, command):
-        self.__mscCommandCombo.setCurrentText(str(command))
-
-    def get_argument_widget(self, msc_arg):
-        return self.__data_widgets[msc_arg][self.DATA_WIDGET]
-
-    def set_argument(self, msc_arg, arg):
-        if msc_arg is MscArgument.TIME_TYPE:
-            if not isinstance(arg, MscTimeType):
-                raise ValueError("not an MscTimeType")
-            self.__data_widgets[msc_arg][self.DATA_WIDGET].setCurrentText(str(arg))
-        elif msc_arg is MscArgument.TIMECODE:
-            if not isinstance(arg, int) and arg < 0:
-                raise ValueError("not an int")
-            self.__data_widgets[msc_arg][self.DATA_WIDGET].setTime(QTime().fromMSecsSinceStartOfDay(arg))
-
-        else:
-            if not isinstance(arg, (int, float)) and arg < 0:
-                raise ValueError("not an int or float")
-            self.__data_widgets[msc_arg][self.DATA_WIDGET].setValue(arg)
-
-    def checkbox_enable(self, msc_arg, enable):
-        self.__data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(enable)
-
-    def checkbox_toggle(self, msc_arg, checked):
-        self.__data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(checked)
-
-    def __retranslateUi(self):
-        self.setTitle(translate('MSCSettings', 'MSC Message'))
-        self.__mscDeviceLabel.setText(translate('MSCSettings', 'Device ID'))
-        self.__mscCmdFmtLabel.setText(translate('MSCSettings', 'Command Format'))
-        self.__mscCommandLabel.setText(translate('MSCSettings', 'MSC Command'))
-        self.__mscQNumberLabel.setText(translate('MSCSettings', 'Q_Number'))
-        self.__mscQListLabel.setText(translate('MSCSettings', 'Q_List'))
-        self.__mscQPathLabel.setText(translate('MSCSettings', 'Q_Path'))
-        self.__mscMacroLabel.setText(translate('MSCSettings', 'Macro Number'))
-        self.__mscCtrlNumLabel.setText(translate('MSCSettings', 'Generic Control  Number'))
-        self.__mscCtrlValLabel.setText(translate('MSCSettings', 'Generic Control  Value'))
-        self.__mscTimecodeLabel.setText(translate('MSCSettings', 'Timecode'))
-
-    def get_message(self):
-        device_id = self.__mscDeviceSpin.value()
-        command = MscCommand(self.__mscCommandCombo.currentText())
-        command_format = MscCommandFormat(self.__mscCmdFmtCombo.currentText())
-
-        message = MscMessage(device_id, command_format, command)
-
-        for msc_arg in MscMessage.get_arguments(command):
-            if self.__data_widgets[msc_arg][self.CHECK_WIDGET].isChecked():
-                if msc_arg is MscArgument.TIME_TYPE:
-                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].currentText()
-                elif msc_arg is MscArgument.TIMECODE:
-                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].time().msecsSinceStartOfDay()
-                else:
-                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].value()
-
-        return message
-
-    def __show_messsage(self):
-        message = self.get_message()
-        self.__mscPreview.setText('MSC:  {0}'.format(message.to_hex_str()))
-
-    def __checked(self, msc_arg, checked):
-        self.__data_widgets[msc_arg][self.DATA_WIDGET].setEnabled(checked)
-
-        if msc_arg is MscArgument.Q_LIST:
-            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
-            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setEnabled(checked)
-
-        elif msc_arg is MscArgument.Q_PATH:
-            self.__data_widgets[MscArgument.Q_LIST][self.CHECK_WIDGET].setEnabled(not checked)
-
-        elif msc_arg is MscArgument.TIMECODE:
-            self.__data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setChecked(checked)
-
-        elif msc_arg is MscArgument.TIME_TYPE:
-            self.__data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setEnabled(False)
-
-        self.__show_messsage()
-
-    def __type_changed(self, cmd_str):
-        cmd = MscCommand(cmd_str)
-        args = MscMessage.get_arguments(cmd)
-        for key, widgets in self.__data_widgets.items():
-            if key in args:
-                if args[key] is cmd:
-                    widgets[self.CHECK_WIDGET].setChecked(True)
-                    widgets[self.CHECK_WIDGET].setEnabled(False)
-                elif key is MscArgument.TIME_TYPE:
-                    pass
-                else:
-                    widgets[self.CHECK_WIDGET].setChecked(True)
-                    widgets[self.CHECK_WIDGET].setEnabled(True)
-            else:
-                widgets[1].setChecked(False)
-                widgets[1].setEnabled(False)
-                widgets[0].setEnabled(False)
 
 
 class MscCueSettings(SettingsPage):

--- a/lisp/modules/action_cues/msc_cue.py
+++ b/lisp/modules/action_cues/msc_cue.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Linux Show Player
+#
+# Copyright 2012-2016 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+import functools
+
+from PyQt5.QtCore import Qt, QT_TRANSLATE_NOOP
+from PyQt5.QtCore import QTime
+from PyQt5.QtWidgets import QGroupBox, QVBoxLayout, QGridLayout, QLabel, \
+    QComboBox, QSpinBox, QDoubleSpinBox, QFrame, QCheckBox, QTimeEdit, QPushButton
+
+from lisp.core.has_properties import Property
+from lisp.cues.cue import Cue
+from lisp.modules.midi.midi_output import MIDIOutput
+from lisp.ui.settings.cue_settings import CueSettingsRegistry
+from lisp.ui.settings.settings_page import SettingsPage
+from lisp.ui.ui_utils import translate
+from lisp.modules.midi.midi_msc import MscMessage, MscCommand, \
+    MscCommandFormat, MscArgument, MscStringParser, MscTimeType
+from lisp.ui import elogging
+
+
+class MscCue(Cue):
+    Name = QT_TRANSLATE_NOOP('CueName', 'MSC Cue')
+
+    message = Property(default='')
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.name = translate('CueName', self.Name)
+
+        midi_out = MIDIOutput()
+        if not midi_out.is_open():
+            midi_out.open()
+
+    def __start__(self, fade=False):
+        if self.message:
+            MIDIOutput().send_from_str(self.message)
+
+        return False
+
+
+class MscCueSettings(SettingsPage):
+    Name = QT_TRANSLATE_NOOP('SettingsPageName', 'MSC Settings')
+
+    DATA_WIDGET = 0
+    CHECK_WIDGET = 1
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+
+        self.mscGroup = QGroupBox(self)
+        self.mscGroup.setLayout(QGridLayout())
+        self.mscGroup.layout().setColumnStretch(0, 10)
+        self.mscGroup.layout().setColumnStretch(1, 10)
+        self.mscGroup.layout().setColumnStretch(2, 1)
+        self.layout().addWidget(self.mscGroup)
+
+        # Device ID
+        self.mscDeviceLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscDeviceLabel, 0, 0)
+        self.mscDeviceSpin = QSpinBox(self.mscGroup)
+        self.mscDeviceSpin.setRange(0, 127)
+        self.mscDeviceSpin.setValue(1)
+        self.mscDeviceSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscDeviceSpin, 0, 1, 1, 2)
+
+        self.mscCmdFmtLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscCmdFmtLabel, 1, 0)
+        self.mscCmdFmtCombo = QComboBox(self.mscGroup)
+        self.mscCmdFmtCombo.addItems([str(i) for i in MscCommandFormat])
+        self.mscCmdFmtCombo.currentTextChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscCmdFmtCombo, 1, 1, 1, 2)
+
+        self.mscCommandLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscCommandLabel, 2, 0)
+        self.mscCommandCombo = QComboBox(self.mscGroup)
+        self.mscCommandCombo.addItems([str(i) for i in MscCommand])
+        self.mscCommandCombo.currentTextChanged.connect(self.__type_changed)
+        self.mscCommandCombo.currentTextChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscCommandCombo, 2, 1, 1, 2)
+
+        line = QFrame(self.mscGroup)
+        line.setFrameShape(QFrame.HLine)
+        line.setFrameShadow(QFrame.Sunken)
+        self.mscGroup.layout().addWidget(line, 3, 0, 1, 3)
+
+        # Data widgets
+        self._data_widgets = {}
+
+        self.mscQNumberLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscQNumberLabel, 4, 0)
+        self.mscQNumberSpin = QDoubleSpinBox(self.mscGroup)
+        self.mscQNumberSpin.setRange(0, 999)
+        self.mscQNumberSpin.setDecimals(3)
+        self.mscQNumberSpin.setSingleStep(1.0)
+        self.mscQNumberSpin.setValue(1)
+        self.mscQNumberSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscQNumberSpin, 4, 1)
+        self.mscQNumberCheck = QCheckBox(self.mscGroup)
+        self.mscQNumberCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_NUMBER))
+        self.mscGroup.layout().addWidget(self.mscQNumberCheck, 4, 2)
+        self._data_widgets[MscArgument.Q_NUMBER] = [self.mscQNumberSpin, self.mscQNumberCheck]
+
+        self.mscQListLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscQListLabel, 5, 0)
+        self.mscQListSpin = QDoubleSpinBox(self.mscGroup)
+        self.mscQListSpin.setRange(0, 999)
+        self.mscQListSpin.setDecimals(3)
+        self.mscQListSpin.setSingleStep(1.0)
+        self.mscQListSpin.setValue(1)
+        self.mscQListSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscQListSpin, 5, 1)
+        self.mscQListCheck = QCheckBox(self.mscGroup)
+        self.mscQListCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_LIST))
+        self.mscGroup.layout().addWidget(self.mscQListCheck, 5, 2)
+        self._data_widgets[MscArgument.Q_LIST] = [self.mscQListSpin, self.mscQListCheck]
+
+        self.mscQPathLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscQPathLabel, 6, 0)
+        self.mscQPathSpin = QDoubleSpinBox(self.mscGroup)
+        self.mscQPathSpin.setRange(0, 999)
+        self.mscQPathSpin.setDecimals(3)
+        self.mscQPathSpin.setSingleStep(1.0)
+        self.mscQPathSpin.setValue(1)
+        self.mscQPathSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscQPathSpin, 6, 1)
+        self.mscQPathCheck = QCheckBox(self.mscGroup)
+        self.mscQPathCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_PATH))
+        self.mscGroup.layout().addWidget(self.mscQPathCheck, 6, 2)
+        self._data_widgets[MscArgument.Q_PATH] = [self.mscQPathSpin, self.mscQPathCheck]
+
+        self.mscMacroLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscMacroLabel, 7, 0)
+        self.mscMacroSpin = QSpinBox(self.mscGroup)
+        self.mscMacroSpin.setRange(0, 127)
+        self.mscMacroSpin.setValue(1)
+        self.mscMacroSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscMacroSpin, 7, 1)
+        self.mscMacroCheck = QCheckBox(self.mscGroup)
+        self.mscMacroCheck.toggled.connect(functools.partial(self.__checked, MscArgument.MACRO_NUM))
+        self.mscGroup.layout().addWidget(self.mscMacroCheck, 7, 2)
+        self._data_widgets[MscArgument.MACRO_NUM] = [self.mscMacroSpin, self.mscMacroCheck]
+
+        self.mscCtrlNumLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscCtrlNumLabel, 8, 0)
+        self.mscCtrlNumSpin = QSpinBox(self.mscGroup)
+        self.mscCtrlNumSpin.setRange(0, 1023)
+        self.mscCtrlNumSpin.setValue(1)
+        self.mscCtrlNumSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscCtrlNumSpin, 8, 1)
+        self.mscCtrlNumCheck = QCheckBox(self.mscGroup)
+        self.mscCtrlNumCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_NUM))
+        self.mscGroup.layout().addWidget(self.mscCtrlNumCheck, 8, 2)
+        self._data_widgets[MscArgument.CTRL_NUM] = [self.mscCtrlNumSpin, self.mscCtrlNumCheck]
+
+        self.mscCtrlValLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscCtrlValLabel, 9, 0)
+        self.mscCtrlValSpin = QSpinBox(self.mscGroup)
+        self.mscCtrlValSpin.setRange(0, 1023)
+        self.mscCtrlValSpin.setValue(1)
+        self.mscCtrlValSpin.valueChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscCtrlValSpin, 9, 1)
+        self.mscCtrlValCheck = QCheckBox(self.mscGroup)
+        self.mscCtrlValCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_VALUE))
+        self.mscGroup.layout().addWidget(self.mscCtrlValCheck, 9, 2)
+        self._data_widgets[MscArgument.CTRL_VALUE] = [self.mscCtrlValSpin, self.mscCtrlValCheck]
+
+        self.mscTimecodeLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscTimecodeLabel, 10, 0)
+        self.mscTimecodeEdit = QTimeEdit(self.mscGroup)
+        self.mscTimecodeEdit.setDisplayFormat('HH.mm.ss.zzz')
+        self.mscTimecodeEdit.timeChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscTimecodeEdit, 10, 1)
+        self.mscTimecodeCheck = QCheckBox(self.mscGroup)
+        self.mscTimecodeCheck.toggled.connect(functools.partial(self.__checked, MscArgument.TIMECODE))
+        self.mscGroup.layout().addWidget(self.mscTimecodeCheck, 10, 2)
+        self._data_widgets[MscArgument.TIMECODE] = [self.mscTimecodeEdit, self.mscTimecodeCheck]
+
+        self.mscTimeTypeLabel = QLabel(self.mscGroup)
+        self.mscGroup.layout().addWidget(self.mscTimeTypeLabel, 11, 0)
+        self.mscTimeTypeCombo = QComboBox(self.mscGroup)
+        self.mscTimeTypeCombo.addItems([str(i) for i in MscTimeType])
+        self.mscTimeTypeCombo.currentTextChanged.connect(self.__show_messsage)
+        self.mscGroup.layout().addWidget(self.mscTimeTypeCombo, 11, 1)
+        self.mscTimeTypeCheck = QCheckBox(self.mscGroup)
+        self.mscTimeTypeCheck .toggled.connect(functools.partial(self.__checked, MscArgument.TIME_TYPE))
+        self.mscGroup.layout().addWidget(self.mscTimeTypeCheck, 11, 2)
+        self._data_widgets[MscArgument.TIME_TYPE] = [self.mscTimeTypeCombo, self.mscTimeTypeCheck]
+
+        self.mscPreview = QLabel(self.mscGroup)
+        self.mscPreview.setStyleSheet('font: bold')
+        self.mscPreview.setMinimumHeight(50)
+        self.mscGroup.layout().addWidget(self.mscPreview, 13, 0, 1, 2)
+
+        self.testButton = QPushButton(self.mscGroup)
+        self.testButton.pressed.connect(self.__test_message)
+        self.mscGroup.layout().addWidget(self.testButton, 13, 2)
+
+        self.retranslateUi()
+
+        self.mscCommandCombo.currentTextChanged.emit(str(MscCommand.GO))
+
+    def retranslateUi(self):
+        self.mscGroup.setTitle(translate('MSCCue', 'MSC Message'))
+        self.mscDeviceLabel.setText(translate('MSCCue', 'Device ID'))
+        self.mscCmdFmtLabel.setText(translate('MSCCue', 'Command Format'))
+        self.mscCommandLabel.setText(translate('MSCCue', 'MSC Command'))
+        self.mscQNumberLabel.setText(translate('MSCCue', 'Q_Number'))
+        self.mscQListLabel.setText(translate('MSCCue', 'Q_List'))
+        self.mscQPathLabel.setText(translate('MSCCue', 'Q_Path'))
+        self.mscMacroLabel.setText(translate('MSCCue', 'Macro Number'))
+        self.mscCtrlNumLabel.setText(translate('MSCCue', 'Generic Control  Number'))
+        self.mscCtrlValLabel.setText(translate('MSCCue', 'Generic Control  Value'))
+        self.mscTimecodeLabel.setText(translate('MSCCue', 'Timecode'))
+        self.testButton.setText(translate('MSCCue', 'Test'))
+
+
+    def __get_message(self):
+        device_id = self.mscDeviceSpin.value()
+        command = MscCommand(self.mscCommandCombo.currentText())
+        command_format = MscCommandFormat(self.mscCmdFmtCombo.currentText())
+
+        message = MscMessage(device_id, command_format, command)
+
+        for msc_arg in MscMessage.get_arguments(command):
+            if self._data_widgets[msc_arg][self.CHECK_WIDGET].isChecked():
+                if msc_arg is MscArgument.TIME_TYPE:
+                    message[msc_arg] = self._data_widgets[msc_arg][self.DATA_WIDGET].currentText()
+                elif msc_arg is MscArgument.TIMECODE:
+                    message[msc_arg] = self._data_widgets[msc_arg][self.DATA_WIDGET].time().msecsSinceStartOfDay()
+                else:
+                    message[msc_arg] = self._data_widgets[msc_arg][self.DATA_WIDGET].value()
+
+        return message
+
+    def __test_message(self):
+        message = self.__get_message()
+        MIDIOutput().send_from_str(message.message_str)
+
+    def __show_messsage(self):
+        message = self.__get_message()
+        self.mscPreview.setText('MSC:  {0}'.format(message.to_hex_str()))
+
+    def __checked(self, msc_arg, checked):
+        self._data_widgets[msc_arg][self.DATA_WIDGET].setEnabled(checked)
+
+        if msc_arg is MscArgument.Q_LIST:
+            self._data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
+            self._data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setEnabled(checked)
+
+        elif msc_arg is MscArgument.Q_PATH:
+            self._data_widgets[MscArgument.Q_LIST][self.CHECK_WIDGET].setEnabled(not checked)
+
+        elif msc_arg is MscArgument.TIMECODE:
+            self._data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setChecked(checked)
+
+        elif msc_arg is MscArgument.TIME_TYPE:
+            self._data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setEnabled(False)
+
+        self.__show_messsage()
+
+    def __type_changed(self, cmd_str):
+        cmd = MscCommand(cmd_str)
+        args = MscMessage.get_arguments(cmd)
+        for key, widgets in self._data_widgets.items():
+            if key in args:
+                if args[key] is cmd:
+                    widgets[self.CHECK_WIDGET].setChecked(True)
+                    widgets[self.CHECK_WIDGET].setEnabled(False)
+                elif key is MscArgument.TIME_TYPE:
+                    pass
+                else:
+                    widgets[self.CHECK_WIDGET].setChecked(True)
+                    widgets[self.CHECK_WIDGET].setEnabled(True)
+            else:
+                widgets[1].setChecked(False)
+                widgets[1].setEnabled(False)
+                widgets[0].setEnabled(False)
+
+    def get_settings(self):
+
+        message = self.__get_message()
+        msg_str = message.message_str
+        if not msg_str:
+            elogging.error("MscCue: could not create MSC messsage")
+
+        elogging.debug("MscCue: message string: {0}".format(msg_str))
+        return {'message': msg_str}
+
+    def load_settings(self, settings):
+        msg_str = settings.get('message', '')
+
+        if not msg_str:
+            return
+
+        print(msg_str)
+        parser = MscStringParser(msg_str)
+
+        if not parser.valid:
+            elogging.error("MscCue: could not parse MSC message")
+            return
+
+        self.mscDeviceSpin.setValue(parser.device_id)
+        self.mscCommandCombo.setCurrentText(str(parser.command))
+        self.mscCmdFmtCombo.setCurrentText(str(parser.command_format))
+
+        for msc_arg in MscArgument:
+            value = parser.get(msc_arg)
+            if value is not None:
+                if msc_arg is MscArgument.TIME_TYPE:
+                    pass
+                elif msc_arg is MscArgument.TIMECODE:
+                    self.mscTimeTypeCombo.setCurrentText(str(parser[MscArgument.TIME_TYPE]))
+                    self.mscTimecodeEdit.setTime(QTime().fromMSecsSinceStartOfDay(value))
+                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(True)
+                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(not parser.required(msc_arg))
+                else:
+                    self._data_widgets[msc_arg][self.DATA_WIDGET].setValue(value)
+                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(True)
+                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(not parser.required(msc_arg))
+
+            else:
+                self._data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(False)
+
+
+CueSettingsRegistry().add_item(MscCueSettings, MscCue)

--- a/lisp/modules/action_cues/msc_cue.py
+++ b/lisp/modules/action_cues/msc_cue.py
@@ -55,164 +55,160 @@ class MscCue(Cue):
         return False
 
 
-class MscGroupBox:
+class MscGroupBox(QGroupBox):
 
     DATA_WIDGET = 0
     CHECK_WIDGET = 1
 
-    def __init__(self):
+    def __init__(self, parent=None):
+        super().__init__(parent)
 
-        self.__mscGroup = QGroupBox(self)
-        self.__mscGroup.setLayout(QGridLayout())
-        self.__mscGroup.layout().setColumnStretch(0, 10)
-        self.__mscGroup.layout().setColumnStretch(1, 10)
-        self.__mscGroup.layout().setColumnStretch(2, 1)
+        self.setLayout(QGridLayout())
+        self.layout().setColumnStretch(0, 10)
+        self.layout().setColumnStretch(1, 10)
+        self.layout().setColumnStretch(2, 1)
 
         # Device ID
-        self.__mscDeviceLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscDeviceLabel, 0, 0)
-        self.__mscDeviceSpin = QSpinBox(self.__mscGroup)
+        self.__mscDeviceLabel = QLabel(self)
+        self.layout().addWidget(self.__mscDeviceLabel, 0, 0)
+        self.__mscDeviceSpin = QSpinBox(self)
         self.__mscDeviceSpin.setRange(0, 127)
         self.__mscDeviceSpin.setValue(0)
         self.__mscDeviceSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscDeviceSpin, 0, 1, 1, 2)
+        self.layout().addWidget(self.__mscDeviceSpin, 0, 1, 1, 2)
 
-        self.__mscCmdFmtLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscCmdFmtLabel, 1, 0)
-        self.__mscCmdFmtCombo = QComboBox(self.__mscGroup)
+        self.__mscCmdFmtLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCmdFmtLabel, 1, 0)
+        self.__mscCmdFmtCombo = QComboBox(self)
         self.__mscCmdFmtCombo.addItems([str(i) for i in MscCommandFormat])
         self.__mscCmdFmtCombo.currentTextChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscCmdFmtCombo, 1, 1, 1, 2)
+        self.layout().addWidget(self.__mscCmdFmtCombo, 1, 1, 1, 2)
 
-        self.__mscCommandLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscCommandLabel, 2, 0)
-        self.__mscCommandCombo = QComboBox(self.__mscGroup)
+        self.__mscCommandLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCommandLabel, 2, 0)
+        self.__mscCommandCombo = QComboBox(self)
         self.__mscCommandCombo.addItems([str(i) for i in MscCommand])
         self.__mscCommandCombo.currentTextChanged.connect(self.__type_changed)
         self.__mscCommandCombo.currentTextChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscCommandCombo, 2, 1, 1, 2)
+        self.layout().addWidget(self.__mscCommandCombo, 2, 1, 1, 2)
 
-        line = QFrame(self.__mscGroup)
+        line = QFrame(self)
         line.setFrameShape(QFrame.HLine)
         line.setFrameShadow(QFrame.Sunken)
-        self.__mscGroup.layout().addWidget(line, 3, 0, 1, 3)
+        self.layout().addWidget(line, 3, 0, 1, 3)
 
         # Data widgets
         self.__data_widgets = {}
 
-        self.__mscQNumberLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscQNumberLabel, 4, 0)
-        self.__mscQNumberSpin = QDoubleSpinBox(self.__mscGroup)
+        self.__mscQNumberLabel = QLabel(self)
+        self.layout().addWidget(self.__mscQNumberLabel, 4, 0)
+        self.__mscQNumberSpin = QDoubleSpinBox(self)
         self.__mscQNumberSpin.setRange(0, 999)
         self.__mscQNumberSpin.setDecimals(3)
         self.__mscQNumberSpin.setSingleStep(1.0)
         self.__mscQNumberSpin.setValue(0)
         self.__mscQNumberSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscQNumberSpin, 4, 1)
-        self.__mscQNumberCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscQNumberSpin, 4, 1)
+        self.__mscQNumberCheck = QCheckBox(self)
         self.__mscQNumberCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_NUMBER))
-        self.__mscGroup.layout().addWidget(self.__mscQNumberCheck, 4, 2)
+        self.layout().addWidget(self.__mscQNumberCheck, 4, 2)
         self.__data_widgets[MscArgument.Q_NUMBER] = [self.__mscQNumberSpin, self.__mscQNumberCheck]
 
-        self.__mscQListLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscQListLabel, 5, 0)
-        self.__mscQListSpin = QDoubleSpinBox(self.__mscGroup)
+        self.__mscQListLabel = QLabel(self)
+        self.layout().addWidget(self.__mscQListLabel, 5, 0)
+        self.__mscQListSpin = QDoubleSpinBox(self)
         self.__mscQListSpin.setRange(0, 999)
         self.__mscQListSpin.setDecimals(3)
         self.__mscQListSpin.setSingleStep(1.0)
         self.__mscQListSpin.setValue(0)
         self.__mscQListSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscQListSpin, 5, 1)
-        self.__mscQListCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscQListSpin, 5, 1)
+        self.__mscQListCheck = QCheckBox(self)
         self.__mscQListCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_LIST))
-        self.__mscGroup.layout().addWidget(self.__mscQListCheck, 5, 2)
+        self.layout().addWidget(self.__mscQListCheck, 5, 2)
         self.__data_widgets[MscArgument.Q_LIST] = [self.__mscQListSpin, self.__mscQListCheck]
 
-        self.__mscQPathLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscQPathLabel, 6, 0)
-        self.__mscQPathSpin = QDoubleSpinBox(self.__mscGroup)
+        self.__mscQPathLabel = QLabel(self)
+        self.layout().addWidget(self.__mscQPathLabel, 6, 0)
+        self.__mscQPathSpin = QDoubleSpinBox(self)
         self.__mscQPathSpin.setRange(0, 999)
         self.__mscQPathSpin.setDecimals(3)
         self.__mscQPathSpin.setSingleStep(1.0)
         self.__mscQPathSpin.setValue(0)
         self.__mscQPathSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscQPathSpin, 6, 1)
-        self.__mscQPathCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscQPathSpin, 6, 1)
+        self.__mscQPathCheck = QCheckBox(self)
         self.__mscQPathCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_PATH))
-        self.__mscGroup.layout().addWidget(self.__mscQPathCheck, 6, 2)
+        self.layout().addWidget(self.__mscQPathCheck, 6, 2)
         self.__data_widgets[MscArgument.Q_PATH] = [self.__mscQPathSpin, self.__mscQPathCheck]
 
-        self.__mscMacroLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscMacroLabel, 7, 0)
-        self.__mscMacroSpin = QSpinBox(self.__mscGroup)
+        self.__mscMacroLabel = QLabel(self)
+        self.layout().addWidget(self.__mscMacroLabel, 7, 0)
+        self.__mscMacroSpin = QSpinBox(self)
         self.__mscMacroSpin.setRange(0, 127)
         self.__mscMacroSpin.setValue(0)
         self.__mscMacroSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscMacroSpin, 7, 1)
-        self.__mscMacroCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscMacroSpin, 7, 1)
+        self.__mscMacroCheck = QCheckBox(self)
         self.__mscMacroCheck.toggled.connect(functools.partial(self.__checked, MscArgument.MACRO_NUM))
-        self.__mscGroup.layout().addWidget(self.__mscMacroCheck, 7, 2)
+        self.layout().addWidget(self.__mscMacroCheck, 7, 2)
         self.__data_widgets[MscArgument.MACRO_NUM] = [self.__mscMacroSpin, self.__mscMacroCheck]
 
-        self.__mscCtrlNumLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscCtrlNumLabel, 8, 0)
-        self.__mscCtrlNumSpin = QSpinBox(self.__mscGroup)
+        self.__mscCtrlNumLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCtrlNumLabel, 8, 0)
+        self.__mscCtrlNumSpin = QSpinBox(self)
         self.__mscCtrlNumSpin.setRange(0, 1023)
         self.__mscCtrlNumSpin.setValue(0)
         self.__mscCtrlNumSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscCtrlNumSpin, 8, 1)
-        self.__mscCtrlNumCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscCtrlNumSpin, 8, 1)
+        self.__mscCtrlNumCheck = QCheckBox(self)
         self.__mscCtrlNumCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_NUM))
-        self.__mscGroup.layout().addWidget(self.__mscCtrlNumCheck, 8, 2)
+        self.layout().addWidget(self.__mscCtrlNumCheck, 8, 2)
         self.__data_widgets[MscArgument.CTRL_NUM] = [self.__mscCtrlNumSpin, self.__mscCtrlNumCheck]
 
-        self.__mscCtrlValLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscCtrlValLabel, 9, 0)
-        self.__mscCtrlValSpin = QSpinBox(self.__mscGroup)
+        self.__mscCtrlValLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCtrlValLabel, 9, 0)
+        self.__mscCtrlValSpin = QSpinBox(self)
         self.__mscCtrlValSpin.setRange(0, 1023)
         self.__mscCtrlValSpin.setValue(0)
         self.__mscCtrlValSpin.valueChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscCtrlValSpin, 9, 1)
-        self.__mscCtrlValCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscCtrlValSpin, 9, 1)
+        self.__mscCtrlValCheck = QCheckBox(self)
         self.__mscCtrlValCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_VALUE))
-        self.__mscGroup.layout().addWidget(self.__mscCtrlValCheck, 9, 2)
+        self.layout().addWidget(self.__mscCtrlValCheck, 9, 2)
         self.__data_widgets[MscArgument.CTRL_VALUE] = [self.__mscCtrlValSpin, self.__mscCtrlValCheck]
 
-        self.__mscTimecodeLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscTimecodeLabel, 10, 0)
-        self.__mscTimecodeEdit = QTimeEdit(self.__mscGroup)
+        self.__mscTimecodeLabel = QLabel(self)
+        self.layout().addWidget(self.__mscTimecodeLabel, 10, 0)
+        self.__mscTimecodeEdit = QTimeEdit(self)
         self.__mscTimecodeEdit.setDisplayFormat('HH.mm.ss.zzz')
         self.__mscTimecodeEdit.timeChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscTimecodeEdit, 10, 1)
-        self.__mscTimecodeCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscTimecodeEdit, 10, 1)
+        self.__mscTimecodeCheck = QCheckBox(self)
         self.__mscTimecodeCheck.toggled.connect(functools.partial(self.__checked, MscArgument.TIMECODE))
-        self.__mscGroup.layout().addWidget(self.__mscTimecodeCheck, 10, 2)
+        self.layout().addWidget(self.__mscTimecodeCheck, 10, 2)
         self.__data_widgets[MscArgument.TIMECODE] = [self.__mscTimecodeEdit, self.__mscTimecodeCheck]
 
-        self.__mscTimeTypeLabel = QLabel(self.__mscGroup)
-        self.__mscGroup.layout().addWidget(self.__mscTimeTypeLabel, 11, 0)
-        self.__mscTimeTypeCombo = QComboBox(self.__mscGroup)
+        self.__mscTimeTypeLabel = QLabel(self)
+        self.layout().addWidget(self.__mscTimeTypeLabel, 11, 0)
+        self.__mscTimeTypeCombo = QComboBox(self)
         self.__mscTimeTypeCombo.addItems([str(i) for i in MscTimeType])
         self.__mscTimeTypeCombo.setCurrentText(str(MscTimeType.SMPTE))
         self.__mscTimeTypeCombo.currentTextChanged.connect(self.__show_messsage)
-        self.__mscGroup.layout().addWidget(self.__mscTimeTypeCombo, 11, 1)
-        self.__mscTimeTypeCheck = QCheckBox(self.__mscGroup)
+        self.layout().addWidget(self.__mscTimeTypeCombo, 11, 1)
+        self.__mscTimeTypeCheck = QCheckBox(self)
         self.__mscTimeTypeCheck .toggled.connect(functools.partial(self.__checked, MscArgument.TIME_TYPE))
-        self.__mscGroup.layout().addWidget(self.__mscTimeTypeCheck, 11, 2)
+        self.layout().addWidget(self.__mscTimeTypeCheck, 11, 2)
         self.__data_widgets[MscArgument.TIME_TYPE] = [self.__mscTimeTypeCombo, self.__mscTimeTypeCheck]
 
-        self.__mscPreview = QLabel(self.__mscGroup)
+        self.__mscPreview = QLabel(self)
         self.__mscPreview.setStyleSheet('font: bold')
         self.__mscPreview.setMinimumHeight(50)
-        self.__mscGroup.layout().addWidget(self.__mscPreview, 13, 0, 1, 2)
+        self.layout().addWidget(self.__mscPreview, 13, 0, 1, 2)
 
         self.__retranslateUi()
 
         self.__mscCommandCombo.currentTextChanged.emit(str(MscCommand.GO))
-
-    @property
-    def widgets(self):
-        return self.__mscGroup
 
     @property
     def device_id(self):
@@ -263,7 +259,7 @@ class MscGroupBox:
         self.__data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(checked)
 
     def __retranslateUi(self):
-        self.__mscGroup.setTitle(translate('MSCSettings', 'MSC Message'))
+        self.setTitle(translate('MSCSettings', 'MSC Message'))
         self.__mscDeviceLabel.setText(translate('MSCSettings', 'Device ID'))
         self.__mscCmdFmtLabel.setText(translate('MSCSettings', 'Command Format'))
         self.__mscCommandLabel.setText(translate('MSCSettings', 'MSC Command'))
@@ -334,27 +330,29 @@ class MscGroupBox:
                 widgets[0].setEnabled(False)
 
 
-class MscCueSettings(SettingsPage, MscGroupBox):
+class MscCueSettings(SettingsPage):
     Name = QT_TRANSLATE_NOOP('SettingsPageName', 'MSC Settings')
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.setLayout(QVBoxLayout())
         self.layout().setAlignment(Qt.AlignTop)
-        self.layout().addWidget(self.widgets)
 
-        self.testButton = QPushButton(self.widgets)
+        self.mscGroup = MscGroupBox(self)
+        self.layout().addWidget(self.mscGroup)
+
+        self.testButton = QPushButton(self.mscGroup)
         self.testButton.pressed.connect(self.__test_message)
         self.testButton.setText(translate('MSCCue', 'Test'))
-        self.widgets.layout().addWidget(self.testButton, 13, 2)
+        self.mscGroup.layout().addWidget(self.testButton, 13, 2)
 
     def __test_message(self):
-        message = self.get_message()
+        message = self.mscGroup.get_message()
         MIDIOutput().send_from_str(message.message_str)
 
     def get_settings(self):
 
-        message = self.get_message()
+        message = self.mscGroup.get_message()
         msg_str = message.message_str
         if not msg_str:
             elogging.error("MscCue: could not create MSC messsage")
@@ -374,9 +372,9 @@ class MscCueSettings(SettingsPage, MscGroupBox):
             elogging.error("MscCue: could not parse MSC message")
             return
 
-        self.device_id = parser.device_id
-        self.command_format = parser.command_format
-        self.command = parser.command
+        self.mscGroup.device_id = parser.device_id
+        self.mscGroup.command_format = parser.command_format
+        self.mscGroup.command = parser.command
 
         for msc_arg in MscArgument:
             value = parser.get(msc_arg)
@@ -384,16 +382,16 @@ class MscCueSettings(SettingsPage, MscGroupBox):
                 if msc_arg is MscArgument.TIME_TYPE:
                     pass
                 elif msc_arg is MscArgument.TIMECODE:
-                    self.set_argument(MscArgument.TIME_TYPE, parser[MscArgument.TIME_TYPE])
-                    self.set_argument(MscArgument.TIMECODE, value)
-                    self.checkbox_toggle(msc_arg, True)
-                    self.checkbox_enable(msc_arg, not parser.required(msc_arg))
+                    self.mscGroup.set_argument(MscArgument.TIME_TYPE, parser[MscArgument.TIME_TYPE])
+                    self.mscGroup.set_argument(MscArgument.TIMECODE, value)
+                    self.mscGroup.checkbox_toggle(msc_arg, True)
+                    self.mscGroup.checkbox_enable(msc_arg, not parser.required(msc_arg))
 
                 else:
-                    self.set_argument(msc_arg, value)
-                    self.checkbox_toggle(msc_arg, True)
-                    self.checkbox_enable(msc_arg, not parser.required(msc_arg))
+                    self.mscGroup.set_argument(msc_arg, value)
+                    self.mscGroup.checkbox_toggle(msc_arg, True)
+                    self.mscGroup.checkbox_enable(msc_arg, not parser.required(msc_arg))
             else:
-                self.checkbox_toggle(msc_arg, False)
+                self.mscGroup.checkbox_toggle(msc_arg, False)
 
 CueSettingsRegistry().add_item(MscCueSettings, MscCue)

--- a/lisp/modules/action_cues/msc_cue.py
+++ b/lisp/modules/action_cues/msc_cue.py
@@ -55,232 +55,270 @@ class MscCue(Cue):
         return False
 
 
-class MscCueSettings(SettingsPage):
-    Name = QT_TRANSLATE_NOOP('SettingsPageName', 'MSC Settings')
+class MscGroupBox:
 
     DATA_WIDGET = 0
     CHECK_WIDGET = 1
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.setLayout(QVBoxLayout())
-        self.layout().setAlignment(Qt.AlignTop)
+    def __init__(self):
 
-        self.mscGroup = QGroupBox(self)
-        self.mscGroup.setLayout(QGridLayout())
-        self.mscGroup.layout().setColumnStretch(0, 10)
-        self.mscGroup.layout().setColumnStretch(1, 10)
-        self.mscGroup.layout().setColumnStretch(2, 1)
-        self.layout().addWidget(self.mscGroup)
+        self.__mscGroup = QGroupBox(self)
+        self.__mscGroup.setLayout(QGridLayout())
+        self.__mscGroup.layout().setColumnStretch(0, 10)
+        self.__mscGroup.layout().setColumnStretch(1, 10)
+        self.__mscGroup.layout().setColumnStretch(2, 1)
 
         # Device ID
-        self.mscDeviceLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscDeviceLabel, 0, 0)
-        self.mscDeviceSpin = QSpinBox(self.mscGroup)
-        self.mscDeviceSpin.setRange(0, 127)
-        self.mscDeviceSpin.setValue(1)
-        self.mscDeviceSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscDeviceSpin, 0, 1, 1, 2)
+        self.__mscDeviceLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscDeviceLabel, 0, 0)
+        self.__mscDeviceSpin = QSpinBox(self.__mscGroup)
+        self.__mscDeviceSpin.setRange(0, 127)
+        self.__mscDeviceSpin.setValue(0)
+        self.__mscDeviceSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscDeviceSpin, 0, 1, 1, 2)
 
-        self.mscCmdFmtLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscCmdFmtLabel, 1, 0)
-        self.mscCmdFmtCombo = QComboBox(self.mscGroup)
-        self.mscCmdFmtCombo.addItems([str(i) for i in MscCommandFormat])
-        self.mscCmdFmtCombo.currentTextChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscCmdFmtCombo, 1, 1, 1, 2)
+        self.__mscCmdFmtLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscCmdFmtLabel, 1, 0)
+        self.__mscCmdFmtCombo = QComboBox(self.__mscGroup)
+        self.__mscCmdFmtCombo.addItems([str(i) for i in MscCommandFormat])
+        self.__mscCmdFmtCombo.currentTextChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscCmdFmtCombo, 1, 1, 1, 2)
 
-        self.mscCommandLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscCommandLabel, 2, 0)
-        self.mscCommandCombo = QComboBox(self.mscGroup)
-        self.mscCommandCombo.addItems([str(i) for i in MscCommand])
-        self.mscCommandCombo.currentTextChanged.connect(self.__type_changed)
-        self.mscCommandCombo.currentTextChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscCommandCombo, 2, 1, 1, 2)
+        self.__mscCommandLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscCommandLabel, 2, 0)
+        self.__mscCommandCombo = QComboBox(self.__mscGroup)
+        self.__mscCommandCombo.addItems([str(i) for i in MscCommand])
+        self.__mscCommandCombo.currentTextChanged.connect(self.__type_changed)
+        self.__mscCommandCombo.currentTextChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscCommandCombo, 2, 1, 1, 2)
 
-        line = QFrame(self.mscGroup)
+        line = QFrame(self.__mscGroup)
         line.setFrameShape(QFrame.HLine)
         line.setFrameShadow(QFrame.Sunken)
-        self.mscGroup.layout().addWidget(line, 3, 0, 1, 3)
+        self.__mscGroup.layout().addWidget(line, 3, 0, 1, 3)
 
         # Data widgets
-        self._data_widgets = {}
+        self.__data_widgets = {}
 
-        self.mscQNumberLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscQNumberLabel, 4, 0)
-        self.mscQNumberSpin = QDoubleSpinBox(self.mscGroup)
-        self.mscQNumberSpin.setRange(0, 999)
-        self.mscQNumberSpin.setDecimals(3)
-        self.mscQNumberSpin.setSingleStep(1.0)
-        self.mscQNumberSpin.setValue(1)
-        self.mscQNumberSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscQNumberSpin, 4, 1)
-        self.mscQNumberCheck = QCheckBox(self.mscGroup)
-        self.mscQNumberCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_NUMBER))
-        self.mscGroup.layout().addWidget(self.mscQNumberCheck, 4, 2)
-        self._data_widgets[MscArgument.Q_NUMBER] = [self.mscQNumberSpin, self.mscQNumberCheck]
+        self.__mscQNumberLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscQNumberLabel, 4, 0)
+        self.__mscQNumberSpin = QDoubleSpinBox(self.__mscGroup)
+        self.__mscQNumberSpin.setRange(0, 999)
+        self.__mscQNumberSpin.setDecimals(3)
+        self.__mscQNumberSpin.setSingleStep(1.0)
+        self.__mscQNumberSpin.setValue(0)
+        self.__mscQNumberSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscQNumberSpin, 4, 1)
+        self.__mscQNumberCheck = QCheckBox(self.__mscGroup)
+        self.__mscQNumberCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_NUMBER))
+        self.__mscGroup.layout().addWidget(self.__mscQNumberCheck, 4, 2)
+        self.__data_widgets[MscArgument.Q_NUMBER] = [self.__mscQNumberSpin, self.__mscQNumberCheck]
 
-        self.mscQListLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscQListLabel, 5, 0)
-        self.mscQListSpin = QDoubleSpinBox(self.mscGroup)
-        self.mscQListSpin.setRange(0, 999)
-        self.mscQListSpin.setDecimals(3)
-        self.mscQListSpin.setSingleStep(1.0)
-        self.mscQListSpin.setValue(1)
-        self.mscQListSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscQListSpin, 5, 1)
-        self.mscQListCheck = QCheckBox(self.mscGroup)
-        self.mscQListCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_LIST))
-        self.mscGroup.layout().addWidget(self.mscQListCheck, 5, 2)
-        self._data_widgets[MscArgument.Q_LIST] = [self.mscQListSpin, self.mscQListCheck]
+        self.__mscQListLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscQListLabel, 5, 0)
+        self.__mscQListSpin = QDoubleSpinBox(self.__mscGroup)
+        self.__mscQListSpin.setRange(0, 999)
+        self.__mscQListSpin.setDecimals(3)
+        self.__mscQListSpin.setSingleStep(1.0)
+        self.__mscQListSpin.setValue(0)
+        self.__mscQListSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscQListSpin, 5, 1)
+        self.__mscQListCheck = QCheckBox(self.__mscGroup)
+        self.__mscQListCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_LIST))
+        self.__mscGroup.layout().addWidget(self.__mscQListCheck, 5, 2)
+        self.__data_widgets[MscArgument.Q_LIST] = [self.__mscQListSpin, self.__mscQListCheck]
 
-        self.mscQPathLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscQPathLabel, 6, 0)
-        self.mscQPathSpin = QDoubleSpinBox(self.mscGroup)
-        self.mscQPathSpin.setRange(0, 999)
-        self.mscQPathSpin.setDecimals(3)
-        self.mscQPathSpin.setSingleStep(1.0)
-        self.mscQPathSpin.setValue(1)
-        self.mscQPathSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscQPathSpin, 6, 1)
-        self.mscQPathCheck = QCheckBox(self.mscGroup)
-        self.mscQPathCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_PATH))
-        self.mscGroup.layout().addWidget(self.mscQPathCheck, 6, 2)
-        self._data_widgets[MscArgument.Q_PATH] = [self.mscQPathSpin, self.mscQPathCheck]
+        self.__mscQPathLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscQPathLabel, 6, 0)
+        self.__mscQPathSpin = QDoubleSpinBox(self.__mscGroup)
+        self.__mscQPathSpin.setRange(0, 999)
+        self.__mscQPathSpin.setDecimals(3)
+        self.__mscQPathSpin.setSingleStep(1.0)
+        self.__mscQPathSpin.setValue(0)
+        self.__mscQPathSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscQPathSpin, 6, 1)
+        self.__mscQPathCheck = QCheckBox(self.__mscGroup)
+        self.__mscQPathCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_PATH))
+        self.__mscGroup.layout().addWidget(self.__mscQPathCheck, 6, 2)
+        self.__data_widgets[MscArgument.Q_PATH] = [self.__mscQPathSpin, self.__mscQPathCheck]
 
-        self.mscMacroLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscMacroLabel, 7, 0)
-        self.mscMacroSpin = QSpinBox(self.mscGroup)
-        self.mscMacroSpin.setRange(0, 127)
-        self.mscMacroSpin.setValue(1)
-        self.mscMacroSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscMacroSpin, 7, 1)
-        self.mscMacroCheck = QCheckBox(self.mscGroup)
-        self.mscMacroCheck.toggled.connect(functools.partial(self.__checked, MscArgument.MACRO_NUM))
-        self.mscGroup.layout().addWidget(self.mscMacroCheck, 7, 2)
-        self._data_widgets[MscArgument.MACRO_NUM] = [self.mscMacroSpin, self.mscMacroCheck]
+        self.__mscMacroLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscMacroLabel, 7, 0)
+        self.__mscMacroSpin = QSpinBox(self.__mscGroup)
+        self.__mscMacroSpin.setRange(0, 127)
+        self.__mscMacroSpin.setValue(0)
+        self.__mscMacroSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscMacroSpin, 7, 1)
+        self.__mscMacroCheck = QCheckBox(self.__mscGroup)
+        self.__mscMacroCheck.toggled.connect(functools.partial(self.__checked, MscArgument.MACRO_NUM))
+        self.__mscGroup.layout().addWidget(self.__mscMacroCheck, 7, 2)
+        self.__data_widgets[MscArgument.MACRO_NUM] = [self.__mscMacroSpin, self.__mscMacroCheck]
 
-        self.mscCtrlNumLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscCtrlNumLabel, 8, 0)
-        self.mscCtrlNumSpin = QSpinBox(self.mscGroup)
-        self.mscCtrlNumSpin.setRange(0, 1023)
-        self.mscCtrlNumSpin.setValue(1)
-        self.mscCtrlNumSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscCtrlNumSpin, 8, 1)
-        self.mscCtrlNumCheck = QCheckBox(self.mscGroup)
-        self.mscCtrlNumCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_NUM))
-        self.mscGroup.layout().addWidget(self.mscCtrlNumCheck, 8, 2)
-        self._data_widgets[MscArgument.CTRL_NUM] = [self.mscCtrlNumSpin, self.mscCtrlNumCheck]
+        self.__mscCtrlNumLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscCtrlNumLabel, 8, 0)
+        self.__mscCtrlNumSpin = QSpinBox(self.__mscGroup)
+        self.__mscCtrlNumSpin.setRange(0, 1023)
+        self.__mscCtrlNumSpin.setValue(0)
+        self.__mscCtrlNumSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscCtrlNumSpin, 8, 1)
+        self.__mscCtrlNumCheck = QCheckBox(self.__mscGroup)
+        self.__mscCtrlNumCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_NUM))
+        self.__mscGroup.layout().addWidget(self.__mscCtrlNumCheck, 8, 2)
+        self.__data_widgets[MscArgument.CTRL_NUM] = [self.__mscCtrlNumSpin, self.__mscCtrlNumCheck]
 
-        self.mscCtrlValLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscCtrlValLabel, 9, 0)
-        self.mscCtrlValSpin = QSpinBox(self.mscGroup)
-        self.mscCtrlValSpin.setRange(0, 1023)
-        self.mscCtrlValSpin.setValue(1)
-        self.mscCtrlValSpin.valueChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscCtrlValSpin, 9, 1)
-        self.mscCtrlValCheck = QCheckBox(self.mscGroup)
-        self.mscCtrlValCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_VALUE))
-        self.mscGroup.layout().addWidget(self.mscCtrlValCheck, 9, 2)
-        self._data_widgets[MscArgument.CTRL_VALUE] = [self.mscCtrlValSpin, self.mscCtrlValCheck]
+        self.__mscCtrlValLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscCtrlValLabel, 9, 0)
+        self.__mscCtrlValSpin = QSpinBox(self.__mscGroup)
+        self.__mscCtrlValSpin.setRange(0, 1023)
+        self.__mscCtrlValSpin.setValue(0)
+        self.__mscCtrlValSpin.valueChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscCtrlValSpin, 9, 1)
+        self.__mscCtrlValCheck = QCheckBox(self.__mscGroup)
+        self.__mscCtrlValCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_VALUE))
+        self.__mscGroup.layout().addWidget(self.__mscCtrlValCheck, 9, 2)
+        self.__data_widgets[MscArgument.CTRL_VALUE] = [self.__mscCtrlValSpin, self.__mscCtrlValCheck]
 
-        self.mscTimecodeLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscTimecodeLabel, 10, 0)
-        self.mscTimecodeEdit = QTimeEdit(self.mscGroup)
-        self.mscTimecodeEdit.setDisplayFormat('HH.mm.ss.zzz')
-        self.mscTimecodeEdit.timeChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscTimecodeEdit, 10, 1)
-        self.mscTimecodeCheck = QCheckBox(self.mscGroup)
-        self.mscTimecodeCheck.toggled.connect(functools.partial(self.__checked, MscArgument.TIMECODE))
-        self.mscGroup.layout().addWidget(self.mscTimecodeCheck, 10, 2)
-        self._data_widgets[MscArgument.TIMECODE] = [self.mscTimecodeEdit, self.mscTimecodeCheck]
+        self.__mscTimecodeLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscTimecodeLabel, 10, 0)
+        self.__mscTimecodeEdit = QTimeEdit(self.__mscGroup)
+        self.__mscTimecodeEdit.setDisplayFormat('HH.mm.ss.zzz')
+        self.__mscTimecodeEdit.timeChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscTimecodeEdit, 10, 1)
+        self.__mscTimecodeCheck = QCheckBox(self.__mscGroup)
+        self.__mscTimecodeCheck.toggled.connect(functools.partial(self.__checked, MscArgument.TIMECODE))
+        self.__mscGroup.layout().addWidget(self.__mscTimecodeCheck, 10, 2)
+        self.__data_widgets[MscArgument.TIMECODE] = [self.__mscTimecodeEdit, self.__mscTimecodeCheck]
 
-        self.mscTimeTypeLabel = QLabel(self.mscGroup)
-        self.mscGroup.layout().addWidget(self.mscTimeTypeLabel, 11, 0)
-        self.mscTimeTypeCombo = QComboBox(self.mscGroup)
-        self.mscTimeTypeCombo.addItems([str(i) for i in MscTimeType])
-        self.mscTimeTypeCombo.currentTextChanged.connect(self.__show_messsage)
-        self.mscGroup.layout().addWidget(self.mscTimeTypeCombo, 11, 1)
-        self.mscTimeTypeCheck = QCheckBox(self.mscGroup)
-        self.mscTimeTypeCheck .toggled.connect(functools.partial(self.__checked, MscArgument.TIME_TYPE))
-        self.mscGroup.layout().addWidget(self.mscTimeTypeCheck, 11, 2)
-        self._data_widgets[MscArgument.TIME_TYPE] = [self.mscTimeTypeCombo, self.mscTimeTypeCheck]
+        self.__mscTimeTypeLabel = QLabel(self.__mscGroup)
+        self.__mscGroup.layout().addWidget(self.__mscTimeTypeLabel, 11, 0)
+        self.__mscTimeTypeCombo = QComboBox(self.__mscGroup)
+        self.__mscTimeTypeCombo.addItems([str(i) for i in MscTimeType])
+        self.__mscTimeTypeCombo.setCurrentText(str(MscTimeType.SMPTE))
+        self.__mscTimeTypeCombo.currentTextChanged.connect(self.__show_messsage)
+        self.__mscGroup.layout().addWidget(self.__mscTimeTypeCombo, 11, 1)
+        self.__mscTimeTypeCheck = QCheckBox(self.__mscGroup)
+        self.__mscTimeTypeCheck .toggled.connect(functools.partial(self.__checked, MscArgument.TIME_TYPE))
+        self.__mscGroup.layout().addWidget(self.__mscTimeTypeCheck, 11, 2)
+        self.__data_widgets[MscArgument.TIME_TYPE] = [self.__mscTimeTypeCombo, self.__mscTimeTypeCheck]
 
-        self.mscPreview = QLabel(self.mscGroup)
-        self.mscPreview.setStyleSheet('font: bold')
-        self.mscPreview.setMinimumHeight(50)
-        self.mscGroup.layout().addWidget(self.mscPreview, 13, 0, 1, 2)
+        self.__mscPreview = QLabel(self.__mscGroup)
+        self.__mscPreview.setStyleSheet('font: bold')
+        self.__mscPreview.setMinimumHeight(50)
+        self.__mscGroup.layout().addWidget(self.__mscPreview, 13, 0, 1, 2)
 
-        self.testButton = QPushButton(self.mscGroup)
-        self.testButton.pressed.connect(self.__test_message)
-        self.mscGroup.layout().addWidget(self.testButton, 13, 2)
+        self.__retranslateUi()
 
-        self.retranslateUi()
+        self.__mscCommandCombo.currentTextChanged.emit(str(MscCommand.GO))
 
-        self.mscCommandCombo.currentTextChanged.emit(str(MscCommand.GO))
+    @property
+    def widgets(self):
+        return self.__mscGroup
 
-    def retranslateUi(self):
-        self.mscGroup.setTitle(translate('MSCCue', 'MSC Message'))
-        self.mscDeviceLabel.setText(translate('MSCCue', 'Device ID'))
-        self.mscCmdFmtLabel.setText(translate('MSCCue', 'Command Format'))
-        self.mscCommandLabel.setText(translate('MSCCue', 'MSC Command'))
-        self.mscQNumberLabel.setText(translate('MSCCue', 'Q_Number'))
-        self.mscQListLabel.setText(translate('MSCCue', 'Q_List'))
-        self.mscQPathLabel.setText(translate('MSCCue', 'Q_Path'))
-        self.mscMacroLabel.setText(translate('MSCCue', 'Macro Number'))
-        self.mscCtrlNumLabel.setText(translate('MSCCue', 'Generic Control  Number'))
-        self.mscCtrlValLabel.setText(translate('MSCCue', 'Generic Control  Value'))
-        self.mscTimecodeLabel.setText(translate('MSCCue', 'Timecode'))
-        self.testButton.setText(translate('MSCCue', 'Test'))
+    @property
+    def device_id(self):
+        return self.__mscDeviceSpin.value()
 
+    @device_id.setter
+    def device_id(self, device_id):
+        self.__mscDeviceSpin.setValue(device_id)
 
-    def __get_message(self):
-        device_id = self.mscDeviceSpin.value()
-        command = MscCommand(self.mscCommandCombo.currentText())
-        command_format = MscCommandFormat(self.mscCmdFmtCombo.currentText())
+    @property
+    def command_format(self):
+        return MscCommandFormat(self.__mscCmdFmtCombo.currentTextChanged())
+
+    @command_format.setter
+    def command_format(self, command_format):
+        self.__mscCmdFmtCombo.setCurrentText(str(command_format))
+
+    @property
+    def command(self):
+        return MscCommand(self.__mscCommandCombo.currentText())
+
+    @command.setter
+    def command(self, command):
+        self.__mscCommandCombo.setCurrentText(str(command))
+
+    def get_argument_widget(self, msc_arg):
+        return self.__data_widgets[msc_arg][self.DATA_WIDGET]
+
+    def set_argument(self, msc_arg, arg):
+        if msc_arg is MscArgument.TIME_TYPE:
+            if not isinstance(arg, MscTimeType):
+                raise ValueError("not an MscTimeType")
+            self.__data_widgets[msc_arg][self.DATA_WIDGET].setCurrentText(str(arg))
+        elif msc_arg is MscArgument.TIMECODE:
+            if not isinstance(arg, int) and arg < 0:
+                raise ValueError("not an int")
+            self.__data_widgets[msc_arg][self.DATA_WIDGET].setTime(QTime().fromMSecsSinceStartOfDay(arg))
+
+        else:
+            if not isinstance(arg, (int, float)) and arg < 0:
+                raise ValueError("not an int or float")
+            self.__data_widgets[msc_arg][self.DATA_WIDGET].setValue(arg)
+
+    def checkbox_enable(self, msc_arg, enable):
+        self.__data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(enable)
+
+    def checkbox_toggle(self, msc_arg, checked):
+        self.__data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(checked)
+
+    def __retranslateUi(self):
+        self.__mscGroup.setTitle(translate('MSCSettings', 'MSC Message'))
+        self.__mscDeviceLabel.setText(translate('MSCSettings', 'Device ID'))
+        self.__mscCmdFmtLabel.setText(translate('MSCSettings', 'Command Format'))
+        self.__mscCommandLabel.setText(translate('MSCSettings', 'MSC Command'))
+        self.__mscQNumberLabel.setText(translate('MSCSettings', 'Q_Number'))
+        self.__mscQListLabel.setText(translate('MSCSettings', 'Q_List'))
+        self.__mscQPathLabel.setText(translate('MSCSettings', 'Q_Path'))
+        self.__mscMacroLabel.setText(translate('MSCSettings', 'Macro Number'))
+        self.__mscCtrlNumLabel.setText(translate('MSCSettings', 'Generic Control  Number'))
+        self.__mscCtrlValLabel.setText(translate('MSCSettings', 'Generic Control  Value'))
+        self.__mscTimecodeLabel.setText(translate('MSCSettings', 'Timecode'))
+
+    def get_message(self):
+        device_id = self.__mscDeviceSpin.value()
+        command = MscCommand(self.__mscCommandCombo.currentText())
+        command_format = MscCommandFormat(self.__mscCmdFmtCombo.currentText())
 
         message = MscMessage(device_id, command_format, command)
 
         for msc_arg in MscMessage.get_arguments(command):
-            if self._data_widgets[msc_arg][self.CHECK_WIDGET].isChecked():
+            if self.__data_widgets[msc_arg][self.CHECK_WIDGET].isChecked():
                 if msc_arg is MscArgument.TIME_TYPE:
-                    message[msc_arg] = self._data_widgets[msc_arg][self.DATA_WIDGET].currentText()
+                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].currentText()
                 elif msc_arg is MscArgument.TIMECODE:
-                    message[msc_arg] = self._data_widgets[msc_arg][self.DATA_WIDGET].time().msecsSinceStartOfDay()
+                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].time().msecsSinceStartOfDay()
                 else:
-                    message[msc_arg] = self._data_widgets[msc_arg][self.DATA_WIDGET].value()
+                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].value()
 
         return message
 
-    def __test_message(self):
-        message = self.__get_message()
-        MIDIOutput().send_from_str(message.message_str)
-
     def __show_messsage(self):
-        message = self.__get_message()
-        self.mscPreview.setText('MSC:  {0}'.format(message.to_hex_str()))
+        message = self.get_message()
+        self.__mscPreview.setText('MSC:  {0}'.format(message.to_hex_str()))
 
     def __checked(self, msc_arg, checked):
-        self._data_widgets[msc_arg][self.DATA_WIDGET].setEnabled(checked)
+        self.__data_widgets[msc_arg][self.DATA_WIDGET].setEnabled(checked)
 
         if msc_arg is MscArgument.Q_LIST:
-            self._data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
-            self._data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setEnabled(checked)
+            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
+            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setEnabled(checked)
 
         elif msc_arg is MscArgument.Q_PATH:
-            self._data_widgets[MscArgument.Q_LIST][self.CHECK_WIDGET].setEnabled(not checked)
+            self.__data_widgets[MscArgument.Q_LIST][self.CHECK_WIDGET].setEnabled(not checked)
 
         elif msc_arg is MscArgument.TIMECODE:
-            self._data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setChecked(checked)
+            self.__data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setChecked(checked)
 
         elif msc_arg is MscArgument.TIME_TYPE:
-            self._data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setEnabled(False)
+            self.__data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setEnabled(False)
 
         self.__show_messsage()
 
     def __type_changed(self, cmd_str):
         cmd = MscCommand(cmd_str)
         args = MscMessage.get_arguments(cmd)
-        for key, widgets in self._data_widgets.items():
+        for key, widgets in self.__data_widgets.items():
             if key in args:
                 if args[key] is cmd:
                     widgets[self.CHECK_WIDGET].setChecked(True)
@@ -295,9 +333,28 @@ class MscCueSettings(SettingsPage):
                 widgets[1].setEnabled(False)
                 widgets[0].setEnabled(False)
 
+
+class MscCueSettings(SettingsPage, MscGroupBox):
+    Name = QT_TRANSLATE_NOOP('SettingsPageName', 'MSC Settings')
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+        self.layout().addWidget(self.widgets)
+
+        self.testButton = QPushButton(self.widgets)
+        self.testButton.pressed.connect(self.__test_message)
+        self.testButton.setText(translate('MSCCue', 'Test'))
+        self.widgets.layout().addWidget(self.testButton, 13, 2)
+
+    def __test_message(self):
+        message = self.get_message()
+        MIDIOutput().send_from_str(message.message_str)
+
     def get_settings(self):
 
-        message = self.__get_message()
+        message = self.get_message()
         msg_str = message.message_str
         if not msg_str:
             elogging.error("MscCue: could not create MSC messsage")
@@ -311,16 +368,15 @@ class MscCueSettings(SettingsPage):
         if not msg_str:
             return
 
-        print(msg_str)
         parser = MscStringParser(msg_str)
 
         if not parser.valid:
             elogging.error("MscCue: could not parse MSC message")
             return
 
-        self.mscDeviceSpin.setValue(parser.device_id)
-        self.mscCommandCombo.setCurrentText(str(parser.command))
-        self.mscCmdFmtCombo.setCurrentText(str(parser.command_format))
+        self.device_id = parser.device_id
+        self.command_format = parser.command_format
+        self.command = parser.command
 
         for msc_arg in MscArgument:
             value = parser.get(msc_arg)
@@ -328,17 +384,16 @@ class MscCueSettings(SettingsPage):
                 if msc_arg is MscArgument.TIME_TYPE:
                     pass
                 elif msc_arg is MscArgument.TIMECODE:
-                    self.mscTimeTypeCombo.setCurrentText(str(parser[MscArgument.TIME_TYPE]))
-                    self.mscTimecodeEdit.setTime(QTime().fromMSecsSinceStartOfDay(value))
-                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(True)
-                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(not parser.required(msc_arg))
+                    self.set_argument(MscArgument.TIME_TYPE, parser[MscArgument.TIME_TYPE])
+                    self.set_argument(MscArgument.TIMECODE, value)
+                    self.checkbox_toggle(msc_arg, True)
+                    self.checkbox_enable(msc_arg, not parser.required(msc_arg))
+
                 else:
-                    self._data_widgets[msc_arg][self.DATA_WIDGET].setValue(value)
-                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(True)
-                    self._data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(not parser.required(msc_arg))
-
+                    self.set_argument(msc_arg, value)
+                    self.checkbox_toggle(msc_arg, True)
+                    self.checkbox_enable(msc_arg, not parser.required(msc_arg))
             else:
-                self._data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(False)
-
+                self.checkbox_toggle(msc_arg, False)
 
 CueSettingsRegistry().add_item(MscCueSettings, MscCue)

--- a/lisp/modules/midi/midi_msc.py
+++ b/lisp/modules/midi/midi_msc.py
@@ -676,7 +676,7 @@ class MscMessage(MscObject):
             if key is MscArgument.Q_NUMBER:
                 chunk = _MscLookupTable.pack_float(self.get(key))
                 if chunk:
-                    data.extend()
+                    data.extend(chunk)
                 else:
                     return None
 

--- a/lisp/modules/midi/midi_msc.py
+++ b/lisp/modules/midi/midi_msc.py
@@ -326,16 +326,13 @@ class _MscLookupTable:
         :return: list of int
         :rtype: list
         """
-        if isinstance(value, float) or isinstance(value, int):
-            l = []
-            for i in "%g" % value:
-                if i.isdigit():
-                    l.append(int(i) + 0x30)
-                else:
-                    l.append(0x2E)
-            return l
-        else:
-            return None
+        l = []
+        for i in "%g" % value:
+            if i.isdigit():
+                l.append(int(i) + 0x30)
+            else:
+                l.append(0x2E)
+        return l
 
     @staticmethod
     def unpack_float(digit_list):
@@ -373,16 +370,13 @@ class _MscLookupTable:
         :return: timecoded milliseconds as five ints
         :rtype: int, int, int, int, int
         """
-        if isinstance(time_type, MscTimeType) and msec > -1:
-            tt = time_tuple(msec)
-            hh = (_MscLookupTable.TIME_TYPE[time_type] << 5) + tt[0]
-            mm = tt[1]  # we use non colour frame (7th bit stays 0)
-            ss = tt[2]  # subframes, standard
-            frame = _MscLookupTable.TIME_TYPE_FRAME[time_type]
-            ff, fr = math.modf(tt[3] / frame)
-            return hh, mm, ss, int(fr), int(ff * 100)
-        else:
-            return None
+        tt = time_tuple(msec)
+        hh = (_MscLookupTable.TIME_TYPE[time_type] << 5) + tt[0]
+        mm = tt[1]  # we use non colour frame (7th bit stays 0)
+        ss = tt[2]  # subframes, standard
+        frame = _MscLookupTable.TIME_TYPE_FRAME[time_type]
+        ff, fr = math.modf(tt[3] / frame)
+        return hh, mm, ss, int(fr), int(ff * 100)
 
     @staticmethod
     def unpack_time_type(data):
@@ -446,10 +440,7 @@ class _MscLookupTable:
         :return: lsb, msb
         :rtype: int, int
         """
-        if isinstance(value, int) and (0 <= value <= 1023):
-            return value & 0x7F, value >> 7
-        else:
-            return None
+        return value & 0x7F, value >> 7
 
     @staticmethod
     def unpack_int16(data):
@@ -674,51 +665,31 @@ class MscMessage(MscObject):
 
         for key in self:
             if key is MscArgument.Q_NUMBER:
-                chunk = _MscLookupTable.pack_float(self.get(key))
-                if chunk:
-                    data.extend(chunk)
-                else:
-                    return None
+                data.extend(_MscLookupTable.pack_float(self.get(key)))
 
             elif key is MscArgument.Q_LIST:
                 chunk = _MscLookupTable.pack_float(self.get(key))
-                if chunk:
-                    if MscArgument.Q_NUMBER in _MscLookupTable.CMD_ARGS[self._command]:
-                        data.append(0x0)
-                    data.extend(chunk)
-                else:
-                    return None
+                if MscArgument.Q_NUMBER in _MscLookupTable.CMD_ARGS[self._command]:
+                    data.append(0x0)
+                data.extend(chunk)
 
             elif key is MscArgument.Q_PATH:
                 chunk = _MscLookupTable.pack_float(self.get(key))
-                if chunk:
-                    if MscArgument.Q_LIST in self:
-                        data.append(0x0)
-                        data.extend(chunk)
-                else:
-                    return None
+                if MscArgument.Q_LIST in self:
+                    data.append(0x0)
+                    data.extend(chunk)
 
             elif key is MscArgument.MACRO_NUM:
-                chunk = self.get(key)
-                if 0 <= chunk <= 127:
-                    data.append(self.get(key))
-                else:
-                    return None
+                data.append(self.get(key))
 
             elif key is MscArgument.CTRL_NUM or key is MscArgument.CTRL_VALUE:
                 chunk = _MscLookupTable.pack_int16(self.get(key))
-                if chunk:
-                    data.extend(chunk)
-                else:
-                    return None
+                data.extend(chunk)
 
             elif key is MscArgument.TIMECODE:
                 time_type = self[MscArgument.TIME_TYPE]
                 timecode = _MscLookupTable.pack_millis(self.get(key), time_type)
-                if timecode:
-                    data.extend(timecode)
-                else:
-                    return None
+                data.extend(timecode)
 
         return data
 

--- a/lisp/modules/midi/midi_msc.py
+++ b/lisp/modules/midi/midi_msc.py
@@ -213,18 +213,17 @@ class _MscLookupTable:
     REV_CMD = {value: key for key, value in CMD.items()}
 
     CMD_ARGS_TYPES = {
-        MscArgument.Q_NUMBER: {'type': float, 'min': 0},
-        MscArgument.Q_PATH: {'type': float, 'min': 0},
-        MscArgument.Q_LIST: {'type': float, 'min': 0},
-        MscArgument.MACRO_NUM: {'type': int, 'min': 0, 'max': 127},
-        MscArgument.CTRL_NUM: {'type': int, 'min': 0, 'max': 1023},
-        MscArgument.CTRL_VALUE: {'type': int, 'min': 0, 'max': 1023},
-        MscArgument.TIMECODE: {'type': int, 'min': 0},
-        MscArgument.TIME_TYPE: {'type': MscTimeType}
+        MscArgument.Q_NUMBER: {'type': float, 'min': 0, 'default': 0},
+        MscArgument.Q_PATH: {'type': float, 'min': 0, 'default': 0},
+        MscArgument.Q_LIST: {'type': float, 'min': 0, 'default': 0},
+        MscArgument.MACRO_NUM: {'type': int, 'min': 0, 'max': 127, 'default': 0},
+        MscArgument.CTRL_NUM: {'type': int, 'min': 0, 'max': 1023, 'default': 0},
+        MscArgument.CTRL_VALUE: {'type': int, 'min': 0, 'max': 1023, 'default': 0},
+        MscArgument.TIMECODE: {'type': int, 'min': 0, 'default': 0},
+        MscArgument.TIME_TYPE: {'type': MscTimeType, 'default': MscTimeType.SMPTE}
     }
 
-    # dict holds MscArguments for certain MscCommands: { MsgArgument: [ required by ] }
-    # required by: None -> optional; MscCommand -> required by command; MscArgument -> only if argument is set
+    # dict holds MscArguments for certain MscCommands: { MsgArgument: [ depends on: MscCommand | MscArgument | None ] }
     CMD_ARGS = {
         MscCommand.GO: {MscArgument.Q_NUMBER: None,
                         MscArgument.Q_LIST: MscArgument.Q_PATH,
@@ -506,8 +505,8 @@ class MscMessage(MscObject):
             if key in self:
                 continue
             else:
-                elogging.error("MscMessage: no valid message missing argument: {0}".format(key), dialog=False)
-                return []
+                self[key] = _MscLookupTable.CMD_ARGS_TYPES[key]['default']
+                elogging.debug("MscMessage: missing argument: {0}, adding default".format(key), dialog=False)
 
         data = [
             0x7F,

--- a/lisp/modules/midi/midi_msc.py
+++ b/lisp/modules/midi/midi_msc.py
@@ -1,0 +1,719 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Linux Show Player
+#
+# Copyright 2012-2016 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+import math
+from collections import UserDict
+from enum import Enum
+import mido
+
+from lisp.core.util import time_tuple
+from lisp.modules.midi.midi_utils import str_msg_to_dict, dict_msg_to_str
+from lisp.ui import elogging
+
+
+class MscArgument(Enum):
+    Q_NUMBER = 'Q_Number'
+    Q_LIST = 'Q_List'
+    Q_PATH = 'Q_Path'
+    MACRO_NUM = 'Macro Number'
+    CTRL_NUM = 'Generic Control Number'
+    CTRL_VALUE = 'Generic Control Value'
+    TIMECODE = 'Timecode'
+    TIME_TYPE = 'Time Type'
+
+    def __str__(self):
+        return self.value
+
+
+class MscCommandFormat(Enum):
+    LIGHTING_GENERAL = 'Lighting (General Category)'
+    MOVING_LIGHTS = 'Moving Lights'
+    COLOR_CHANGERS = 'Colour Changers'
+    STROBES = 'Strobes'
+    LASERS = 'Lasers'
+    CHASERS = 'Chasers'
+    SOUND_GENERAL = 'Sound (General Category)'
+    MUSIC = 'Music'
+    CD_PLAYERS = 'CD Players'
+    EPROM_PLAYBACK = 'EPROM Playback'
+    AUDIO_TAPE_MACHINES = 'Audio Tape Machines'
+    INTERCOMS = 'Intercoms'
+    AMPLIFIERS = 'Amplifiers'
+    AUDIO_EFFECT_DEVICES = 'Audio Effects Devices'
+    EQUALISERS = 'Equalisers'
+    # 'Machinery (General Category)'
+    # 'Rigging'
+    # 'Flys'
+    # 'Lifts'
+    # 'Turntables'
+    # 'Trusses'
+    # 'Robots'
+    # 'Animation'
+    # 'Floats'
+    # 'Breakaways'
+    # 'Barges'
+    VIDEO_GENERAL = 'Video (General Category)'
+    VIDEO_TAPE_MACHINES = 'Video Tape Machines'
+    VIDEO_CASSETTE_MACHINE = 'Video Cassette Machines'
+    VIDEO_DISC_PLAYERS = 'Video Disc Players'
+    VIDEO_SWITCHERS = 'Video Switchers'
+    VIDEO_EFFECTS = 'Video Effects'
+    VIDEO_CHARACTER_GENERATORS = 'Video Character Generators'
+    VIDEO_STILL_SCORES = 'Video Still Stores'
+    VIDEO_MONITORS = 'Video Monitors'
+    PROJECTION_GENERAL = 'Projection (General Category)'
+    FILM_PROJECTORS = 'Film Projectors'
+    SLIDE_PROJECTORS = 'Slide Projectors'
+    VIDEO_PROJECTORS = 'Video Projectors'
+    DISSOLVERS = 'Dissolvers'
+    SHUTTER_CONTROL = 'Shutter Controls'
+    # 'Process Control (General Category)'
+    # 'Hydraulic Oil'
+    # 'H20'
+    # 'CO2'
+    # 'Compressed Air'
+    # 'Natural Gas'
+    # 'Fog'
+    # 'Smoke'
+    # 'Cracked Haze'
+    # 'Pyro  (General Category)'
+    # 'Fireworks'
+    # 'Explosions'
+    # 'Flame'
+    # 'Smoke pots'
+    ALL_TYPES = 'All-types'
+
+    def __str__(self):
+        return self.value
+
+
+class MscCommand(Enum):
+    GO = 'Go'
+    STOP = 'Stop'
+    RESUME = 'Resume'
+    TIMED_GO = 'Timed Go'
+    LOAD = 'Load'
+    SET = 'Set'
+    FIRE = 'Fire'
+    ALL_OFF = 'All Off'
+    RESTORE = 'Restore'
+    RESET = 'Reset'
+    GO_OFF = 'Go Off'
+    GO_JAM_CLOCK = 'Go/Jam Clock'
+    STANDBY_PLUS = 'Standby +'
+    STANDBY_MINUS = 'Standby -'
+    SEQUENCE_PLUS = 'Sequence +'
+    SEQUENCE_MINUS = 'Sequence -'
+    START_CLOCK = 'Start Clock'
+    STOP_CLOCK = 'Stop Clock'
+    ZERO_CLOCK = 'Zero Clock'
+    SET_CLOCK = 'Set Clock'
+    MTC_CHASE_ON = 'MTC Chase On'
+    MTC_CHASE_OFF = 'MTC Chase Off'
+    OPEN_CUE_LIST = 'Open Cuelist'
+    CLOSE_CUE_LIST = 'Close Cuelist'
+    OPEN_CUE_PATH = 'Open Cue Path'
+    CLOSE_CUE_PATH = 'Close Cue Path'
+
+    def __str__(self):
+        return self.value
+
+
+class MscTimeType(Enum):
+    FILM = 'Film 24 frame'
+    EBU = 'EBU 25 frame'
+    SMPTE = 'SMPTE 30 frame'
+
+    def __str__(self):
+        return self.value
+
+
+class _MscLookupTable:
+    CMD_FMT = {
+        MscCommandFormat.LIGHTING_GENERAL: 0x1,
+        MscCommandFormat.MOVING_LIGHTS: 0x2,
+        MscCommandFormat.COLOR_CHANGERS: 0x3,
+        MscCommandFormat.STROBES: 0x4,
+        MscCommandFormat.LASERS: 0x5,
+        MscCommandFormat.CHASERS: 0x6,
+        MscCommandFormat.SOUND_GENERAL: 0x10,
+        MscCommandFormat.MUSIC: 0x11,
+        MscCommandFormat.CD_PLAYERS: 0x12,
+        MscCommandFormat.EPROM_PLAYBACK: 0x13,
+        MscCommandFormat.AUDIO_TAPE_MACHINES: 0x14,
+        MscCommandFormat.INTERCOMS: 0x15,
+        MscCommandFormat.AMPLIFIERS: 0x16,
+        MscCommandFormat.AUDIO_EFFECT_DEVICES: 0x17,
+        MscCommandFormat.EQUALISERS: 0x18,
+        MscCommandFormat.VIDEO_GENERAL: 0x30,
+        MscCommandFormat.VIDEO_TAPE_MACHINES: 0x31,
+        MscCommandFormat.VIDEO_CASSETTE_MACHINE: 0x32,
+        MscCommandFormat.VIDEO_DISC_PLAYERS: 0x33,
+        MscCommandFormat.VIDEO_SWITCHERS: 0x34,
+        MscCommandFormat.VIDEO_EFFECTS: 0x35,
+        MscCommandFormat.VIDEO_CHARACTER_GENERATORS: 0x36,
+        MscCommandFormat.VIDEO_STILL_SCORES: 0x37,
+        MscCommandFormat.VIDEO_MONITORS: 0x38,
+        MscCommandFormat.PROJECTION_GENERAL: 0x40,
+        MscCommandFormat.FILM_PROJECTORS: 0x41,
+        MscCommandFormat.SLIDE_PROJECTORS: 0x42,
+        MscCommandFormat.VIDEO_PROJECTORS: 0x43,
+        MscCommandFormat.DISSOLVERS: 0x44,
+        MscCommandFormat.SHUTTER_CONTROL: 0x45,
+        MscCommandFormat.ALL_TYPES: 0x7F
+    }
+
+    REV_CMD_FMT = {value: key for key, value in CMD_FMT.items()}
+
+    CMD = {
+        MscCommand.GO: 0x1,
+        MscCommand.STOP: 0x2,
+        MscCommand.RESUME: 0x03,
+        MscCommand.TIMED_GO: 0x04,
+        MscCommand.LOAD: 0x05,
+        MscCommand.SET: 0x06,
+        MscCommand.FIRE: 0x07,
+        MscCommand.ALL_OFF: 0x08,
+        MscCommand.RESTORE: 0x09,
+        MscCommand.RESET: 0x0A,
+        MscCommand.GO_OFF: 0x0B,
+        MscCommand.GO_JAM_CLOCK: 0x10,
+        MscCommand.STANDBY_PLUS: 0x11,
+        MscCommand.STANDBY_MINUS: 0x12,
+        MscCommand.SEQUENCE_PLUS: 0x13,
+        MscCommand.SEQUENCE_MINUS: 0x14,
+        MscCommand.START_CLOCK: 0x15,
+        MscCommand.STOP_CLOCK: 0x16,
+        MscCommand.ZERO_CLOCK: 0x17,
+        MscCommand.SET_CLOCK: 0x18,
+        MscCommand.MTC_CHASE_ON: 0x19,
+        MscCommand.MTC_CHASE_OFF: 0x1A,
+        MscCommand.OPEN_CUE_LIST: 0x1B,
+        MscCommand.CLOSE_CUE_LIST: 0x1C,
+        MscCommand.OPEN_CUE_PATH: 0x1D,
+        MscCommand.CLOSE_CUE_PATH: 0x1E
+    }
+
+    REV_CMD = {value: key for key, value in CMD.items()}
+
+    CMD_ARGS_TYPES = {
+        MscArgument.Q_NUMBER: {'type': float, 'min': 0},
+        MscArgument.Q_PATH: {'type': float, 'min': 0},
+        MscArgument.Q_LIST: {'type': float, 'min': 0},
+        MscArgument.MACRO_NUM: {'type': int, 'min': 0, 'max': 127},
+        MscArgument.CTRL_NUM: {'type': int, 'min': 0, 'max': 1023},
+        MscArgument.CTRL_VALUE: {'type': int, 'min': 0, 'max': 1023},
+        MscArgument.TIMECODE: {'type': int, 'min': 0},
+        MscArgument.TIME_TYPE: {'type': MscTimeType}
+    }
+
+    # dict holds MscArguments for certain MscCommands: { MsgArgument: [ required by ] }
+    # required by: None -> optional; MscCommand -> required by command; MscArgument -> only if argument is set
+    CMD_ARGS = {
+        MscCommand.GO: {MscArgument.Q_NUMBER: None,
+                        MscArgument.Q_LIST: MscArgument.Q_PATH,
+                        MscArgument.Q_PATH: None},
+
+        MscCommand.STOP: {MscArgument.Q_NUMBER: None,
+                          MscArgument.Q_LIST: MscArgument.Q_PATH,
+                          MscArgument.Q_PATH: None},
+
+        MscCommand.RESUME: {MscArgument.Q_NUMBER: None,
+                            MscArgument.Q_LIST: MscArgument.Q_PATH,
+                            MscArgument.Q_PATH: None},
+
+        MscCommand.TIMED_GO: {MscArgument.TIMECODE: MscCommand.TIMED_GO,
+                              MscArgument.TIME_TYPE: MscCommand.TIMED_GO,
+                              MscArgument.Q_NUMBER: None,
+                              MscArgument.Q_LIST: MscArgument.Q_PATH,
+                              MscArgument.Q_PATH: None},
+
+        MscCommand.LOAD: {MscArgument.Q_NUMBER: None,
+                          MscArgument.Q_LIST: MscArgument.Q_PATH,
+                          MscArgument.Q_PATH: None},
+
+        MscCommand.SET: {MscArgument.CTRL_NUM: MscCommand.SET,
+                         MscArgument.CTRL_VALUE: MscCommand.SET,
+                         MscArgument.TIMECODE: None,
+                         MscArgument.TIME_TYPE: MscArgument.TIMECODE},
+
+        MscCommand.FIRE: {MscArgument.MACRO_NUM: MscCommand.FIRE},
+
+        MscCommand.ALL_OFF: {},
+
+        MscCommand.RESTORE: {},
+
+        MscCommand.RESET: {},
+
+        MscCommand.GO_OFF: {MscArgument.Q_NUMBER: None,
+                            MscArgument.Q_LIST: MscArgument.Q_PATH,
+                            MscArgument.Q_PATH: None},
+
+        MscCommand.GO_JAM_CLOCK: {MscArgument.Q_NUMBER: None,
+                                  MscArgument.Q_LIST: MscArgument.Q_PATH,
+                                  MscArgument.Q_PATH: None},
+
+        MscCommand.STANDBY_PLUS: {MscArgument.Q_LIST: None},
+
+        MscCommand.STANDBY_MINUS: {MscArgument.Q_LIST: None},
+
+        MscCommand.SEQUENCE_PLUS: {MscArgument.Q_LIST: None},
+
+        MscCommand.SEQUENCE_MINUS: {MscArgument.Q_LIST: None},
+
+        MscCommand.START_CLOCK: {MscArgument.Q_LIST: None},
+
+        MscCommand.STOP_CLOCK: {MscArgument.Q_LIST: None},
+
+        MscCommand.ZERO_CLOCK: {MscArgument.Q_LIST: None},
+
+        MscCommand.SET_CLOCK: {MscArgument.TIMECODE: MscCommand.SET_CLOCK,
+                               MscArgument.TIME_TYPE: MscCommand.SET_CLOCK,
+                               MscArgument.Q_LIST: None},
+
+        MscCommand.MTC_CHASE_ON: {MscArgument.Q_LIST: None},
+
+        MscCommand.MTC_CHASE_OFF: {MscArgument.Q_LIST: None},
+
+        MscCommand.OPEN_CUE_LIST: {MscArgument.Q_LIST: MscCommand.OPEN_CUE_LIST},
+
+        MscCommand.CLOSE_CUE_LIST: {MscArgument.Q_LIST: MscCommand.CLOSE_CUE_LIST},
+
+        MscCommand.OPEN_CUE_PATH: {MscArgument.Q_LIST: MscCommand.CLOSE_CUE_LIST},
+
+        MscCommand.CLOSE_CUE_PATH: {MscArgument.Q_LIST: MscCommand.CLOSE_CUE_PATH}
+    }
+
+    TIME_TYPE = {
+        MscTimeType.FILM: 0x0,
+        MscTimeType.EBU: 0x1,
+        MscTimeType.SMPTE: 0x3
+    }
+
+    REV_TIME_TYPE = {value: key for key, value in TIME_TYPE.items()}
+
+    TIME_TYPE_FRAME = {
+        MscTimeType.FILM: 1000 / 24,
+        MscTimeType.EBU: 1000 / 25,
+        MscTimeType.SMPTE: 1000 / 30
+    }
+
+
+class MscObject(UserDict):
+    def __init__(self):
+        super().__init__(self)
+
+        self._device_id = None
+        self._command_format = None
+        self._command = None
+
+    def __str__(self):
+        return ', '.join([
+            'DeviceID = {0}'.format(self._device_id),
+            'CommandFormat = {0}'.format(self._command_format),
+            'Command = {0}'.format(self._command),
+            *('{0} = {1}'.format(k, v) for k, v in self.items())
+        ])
+
+    @property
+    def device_id(self):
+        """
+
+        :rtype: int
+        """
+        return self._device_id
+
+    @device_id.setter
+    def device_id(self, device_id):
+        """
+
+        :param device_id: Msc Device ID
+        :type device_id: int
+        """
+        self._device_id = device_id
+
+    @property
+    def command_format(self):
+        """
+
+        :rtype: MscCommandFormat
+        """
+        return self._command_format
+
+    @command_format.setter
+    def command_format(self, command_format):
+        """
+
+        :param command_format: Msc Command Format
+        :type command_format: MscCommandFormat
+        """
+        self._command_format = command_format
+
+    @property
+    def command(self):
+        """
+
+        :rtype: MscCommand
+        """
+        return self._command
+
+    @command.setter
+    def command(self, command):
+        """
+
+        :param command: Msc Command
+        :type command: MscCommand
+        """
+        self._command = command
+        self.data.clear()
+
+    def required(self, key):
+        """
+        checks if the requested key is required for the message or optional
+        :param key: MSC message argument
+        :type key: MscArgument
+        :return: True if required for message
+        :rtype: bool
+        """
+        if not isinstance(key, MscArgument):
+            raise TypeError("key is not type MscArgument")
+
+        if key in _MscLookupTable.CMD_ARGS[self._command]:
+            required = _MscLookupTable.CMD_ARGS[self._command].get(key, None)
+            if required is self._command:
+                return True
+            elif isinstance(required, MscArgument) and required in self:
+                return True
+            else:
+                return False
+
+    def _get_required(self):
+        for key, req in _MscLookupTable.CMD_ARGS[self._command].items():
+            if self.required(key):
+                yield key
+
+    @staticmethod
+    def message_is_msc(message):
+        """
+        minimum check, only sysex and min length, manufacturer id and Msc Sub ID
+        use this method to check if parsing would make sense
+        :param message: Midi Message
+        :type message: mido.Message
+        :return: returns True if message is a MSC message
+        :rtype: bool
+        """
+        return isinstance(message, mido.Message) \
+               and message.type == 'sysex' \
+               and len(message.data) > 4 \
+               and message.data[0] == 0x7F \
+               and message.data[2] == 0x02
+
+
+    @staticmethod
+    def str_is_msc(message_str):
+        """
+        minimum check, only sysex and min length, manufacturer id and Msc Sub ID
+        use this method to check if parsing would make sense
+        :param message: Midi Message string
+        :type message: str
+        :return: returns True if message is a MSC message
+        :rtype: bool
+        """
+        if not isinstance(message_str, str):
+            return False
+        try:
+            message = str_msg_to_dict(message_str)
+            return message.get('type', '') == 'sysex' \
+                   and message.get('data', None) \
+                   and len(message['data']) > 4 \
+                   and message.data[0] == 0x7F \
+                   and message.data[2] == 0x02
+        except ValueError:
+            return False
+
+    @staticmethod
+    def get_arguments(command):
+        return _MscLookupTable.CMD_ARGS.get(command)
+
+
+class MscMessage(MscObject):
+    def __init__(self, device_id, command_format, command):
+        """
+        MscMessage: creates Midi MSC Message
+        :param device_id: Device ID
+        :type device_id: int
+        :param command_format: MSC Command Format (LIGHTING_GENERAL, ...)
+        :type command_format: MscCommandFormat
+        :param command: MSC Command (GO, STOP, ...)
+        :type command: MscCommand
+        """
+        super().__init__()
+        if not isinstance(device_id, int):
+            raise TypeError("device_id is not type int")
+
+        if not isinstance(command_format, MscCommandFormat):
+            raise TypeError("device_id is not type MscCommandFormat")
+
+        if not isinstance(command, MscCommand):
+            raise TypeError("device_id is not type MscCommand")
+
+        self._device_id = device_id
+        self._command_format = command_format
+        self._command = command
+
+    def __setitem__(self, key, value):
+        if isinstance(key, MscArgument) and key in _MscLookupTable.CMD_ARGS[self._command]:
+            type_descr = _MscLookupTable.CMD_ARGS_TYPES[key]
+            if 'max' in type_descr:
+                value = min(value, type_descr['max'])
+            if 'min' in type_descr:
+                value = max(type_descr['min'], value)
+            self.data[key] = type_descr['type'](value)
+        else:
+            elogging.error(
+                "MscMessage: could not add argument: '{0}' to Command: '{1}'".format(str(key), str(self._command)))
+
+    @property
+    def message_str(self):
+        """
+        returns a MSC mido sysex message string
+        :rtype: str
+        """
+        data = self.__create_msg()
+        if data:
+            return dict_msg_to_str({'type': 'sysex', 'data': data})
+        else:
+            return ''
+
+    def __create_msg(self):
+        for key in self._get_required():
+            if key in self:
+                continue
+            else:
+                elogging.error("MscMessage: no valid message missing argument: {0}".format(key), dialog=False)
+                return []
+
+        data = [
+            0x7F,
+            self._device_id,
+            0x02,
+            _MscLookupTable.CMD_FMT[self._command_format],
+            _MscLookupTable.CMD[self._command]
+        ]
+
+        for key in self:
+            if key is MscArgument.Q_NUMBER:
+                data.extend(self.__encode_q(self.get(key)))
+
+            elif key is MscArgument.Q_LIST:
+                if MscArgument.Q_NUMBER in _MscLookupTable.CMD_ARGS[self._command]:
+                    data.append(0x0)
+                data.extend(self.__encode_q(self.get(key)))
+
+            elif key is MscArgument.Q_PATH:
+                if MscArgument.Q_LIST in self:
+                    data.append(0x0)
+                    data.extend(self.__encode_q(self.get(key)))
+
+            elif key is MscArgument.MACRO_NUM:
+                data.append(self.get(key))
+
+            elif key is MscArgument.CTRL_NUM or key is MscArgument.CTRL_VALUE:
+                data.append(self.get(key) & 0x7f)
+                data.append(self.get(key) >> 7)
+
+            elif key is MscArgument.TIMECODE:
+                time_type = self[MscArgument.TIME_TYPE]
+                timecode = self.__encode_timecode(self.get(key), time_type)
+                data.extend(timecode)
+        return data
+
+    @staticmethod
+    def __encode_q(value):
+        l = []
+        for i in "%g" % value:
+            if i.isdigit():
+                l.append(int(i) + 0x30)
+            else:
+                l.append(0x2E)
+        return l
+
+    def __encode_timecode(self, msec, time_type):
+        tt = time_tuple(msec)
+        hh = (_MscLookupTable.TIME_TYPE[time_type] << 5) + tt[0]
+        mm = tt[1]  # we use non colour frame (7th bit stays 0)
+        ss = tt[2]  # subframes, standard
+        frame = _MscLookupTable.TIME_TYPE_FRAME[time_type]
+        ff, fr = math.modf(tt[3] / frame)
+        return [hh, mm, ss, int(fr), int(ff * 100)]
+
+    def to_hex_str(self):
+        """
+        Message in  hex strings: 7F Device_ID 02 <Command Format> <Command> <Data> <F7>
+        :return: hex string of the MSC message
+        :rtype: str
+        """
+        msg_list = [0xF0]
+        data = self.__create_msg()
+        if data:
+            msg_list.extend(data)
+            msg_list.append(0xF7)
+            return ' '.join(['{0:02x}'.format(i).upper() for i in msg_list])
+        else:
+            return ''
+
+
+class MscParser(MscObject):
+    def __init__(self, message):
+        """
+        midi msc message parses the arguments
+        :param message: midi msc sysex message
+        :type message: mido.Message
+        """
+        super().__init__()
+
+        if not MscParser.message_is_msc(message):
+            raise ValueError('message is not an msc midi message')
+
+        self.__message = message
+        self.__valid = True
+        self._device_id = message.data[1]
+
+        try:
+            self._command_format = _MscLookupTable.REV_CMD_FMT[message.data[3]]
+            self._command = _MscLookupTable.REV_CMD[message.data[4]]
+        except KeyError:
+            self._command = None
+            self._command_format = None
+            self.__valid = False
+            return
+
+        data = list(message.data)[5:]
+
+        for msc_arg in _MscLookupTable.CMD_ARGS[self._command]:
+            if not len(data):
+                return
+
+            if msc_arg is MscArgument.Q_NUMBER:
+                if 0x0 in data:
+                    index = data.index(0x0)
+                    if index == 0:
+                        data.pop(0)
+                        continue
+                    value = self.__join_float(data[:index])
+                    data = data[index + 1:]
+                else:
+                    value = self.__join_float(data)
+                    data.clear()
+
+                self.data[msc_arg] = value
+
+            if msc_arg is msc_arg is MscArgument.Q_LIST \
+                    or msc_arg is MscArgument.Q_PATH:
+
+                if 0x0 in data:
+                    index = data.index(0x0)
+                    value = self.__join_float(data[:index])
+                    data = data[index + 1:]
+                else:
+                    value = self.__join_float(data)
+                    data.clear()
+
+                self.data[msc_arg] = value
+
+            elif msc_arg is MscArgument.MACRO_NUM:
+                self.data[msc_arg] = data[0]
+                data.pop(0)
+
+            elif msc_arg is MscArgument.CTRL_NUM \
+                    or msc_arg is MscArgument.CTRL_VALUE:
+
+                if len(data) < 2:
+                    return
+
+                ctrl_bytes = data[:2]
+                value = ctrl_bytes[0] + (ctrl_bytes[1] << 7)
+                self.data[msc_arg] = value
+                data = data[2:]
+
+            elif msc_arg is MscArgument.TIME_TYPE:
+                pass
+
+            elif msc_arg is MscArgument.TIMECODE or msc_arg is MscArgument.TIME_TYPE:
+                time_type_bits = (data[0] & int('1100000', 2)) >> 5
+                time_type = _MscLookupTable.REV_TIME_TYPE[time_type_bits]
+                self.data[MscArgument.TIME_TYPE] = time_type
+
+                frame_duration = _MscLookupTable.TIME_TYPE_FRAME[time_type]
+
+                hour = (data[0] & int('11111', 2)) * 3600000
+                minute = (data[1] & int('111111', 2)) * 60000
+                sec = (data[2] & int('111111', 2)) * 1000
+
+                fr = data[3] & int('11111', 2)
+                # test on subframes (bit 6 : 0)
+
+                subframe = data[3] & int('00100000', 2)
+                if not subframe:
+                    ff = data[4] & int('1111111', 2)
+                    fr += ff / 100
+
+                msec = int(fr * frame_duration)
+
+                self.data[MscArgument.TIMECODE] = hour + minute + sec + msec
+                data = data[5:]
+
+        for key in self._get_required():
+            if key in self:
+                continue
+            else:
+                elogging.error("MscMessage: not a valid msc message missing argument: {0}".format(key), dialog=False)
+                self.__valid = False
+
+    def __setitem__(self, key, value):
+        raise RuntimeError("writing to Parser not possible")
+
+    @property
+    def valid(self):
+        return self.__valid
+
+    @staticmethod
+    def __join_float(digit_list):
+        if 0x2e in digit_list:
+            point = digit_list.index(0x2e)
+            digit_list.pop(point)
+        else:
+            point = len(digit_list)
+        index = 0
+        val = 0
+        for i in reversed(range(-(len(digit_list[point:])), point)):
+            digit = ~0x30 & digit_list[index]
+            val += 10 ** i * digit
+            index += 1
+        return val
+
+
+class MscStringParser(MscParser):
+    def __init__(self, message_str):
+        """
+        midi msc message string and parses the arguments
+        :param message: midi msc sysex as string
+        :type message: str
+        """
+        super().__init__(mido.parse_string(message_str))

--- a/lisp/modules/midi/midi_msc.py
+++ b/lisp/modules/midi/midi_msc.py
@@ -223,7 +223,7 @@ class _MscLookupTable:
         MscArgument.TIME_TYPE: {'type': MscTimeType, 'default': MscTimeType.SMPTE}
     }
 
-    # dict holds MscArguments for certain MscCommands: { MsgArgument: [ depends on: MscCommand | MscArgument | None ] }
+    # dict holds MscArguments for certain MscCommands: { MsgArgument: [ required by: MscCommand | MscArgument | None ] }
     CMD_ARGS = {
         MscCommand.GO: {MscArgument.Q_NUMBER: None,
                         MscArgument.Q_LIST: MscArgument.Q_PATH,

--- a/lisp/modules/midi/midi_msc.py
+++ b/lisp/modules/midi/midi_msc.py
@@ -500,6 +500,10 @@ class MscMessage(MscObject):
         else:
             return ''
 
+    @property
+    def message(self):
+        return mido.parse_string(self.message_str)
+
     def __create_msg(self):
         for key in self._get_required():
             if key in self:

--- a/lisp/plugins/controller/protocols/msc.py
+++ b/lisp/plugins/controller/protocols/msc.py
@@ -46,7 +46,6 @@ class Msc(Protocol):
 
     def __new_message(self, message):
         if message.type == 'sysex':
-            print(Msc.str_from_message(message))
             self.protocol_event.emit(Msc.str_from_message(message))
 
     @staticmethod

--- a/lisp/plugins/controller/protocols/msc.py
+++ b/lisp/plugins/controller/protocols/msc.py
@@ -18,20 +18,23 @@
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
 from PyQt5.QtCore import Qt, QT_TRANSLATE_NOOP
-from PyQt5.QtWidgets import QGroupBox, QPushButton, QComboBox, QVBoxLayout, \
-    QMessageBox, QTableView, QTableWidget, QHeaderView, QGridLayout
+from PyQt5.QtWidgets import QGroupBox, QPushButton, QDialog, QVBoxLayout, \
+    QTableView, QTableWidget, QHeaderView, QGridLayout, \
+    QDialogButtonBox
 
+from lisp.plugins.controller.protocols.protocol import Protocol
 from lisp.modules import check_module
 from lisp.modules.midi.midi_input import MIDIInput
-from lisp.plugins.controller.protocols.midi import Midi
-from lisp.ui.qdelegates import ComboBoxDelegate, SpinBoxDelegate, \
-    CueActionDelegate, LineEditDelegate
+from lisp.modules.midi.midi_msc import MscParser, MscArgument
+from lisp.ui import elogging
+from lisp.ui.qdelegates import CueActionDelegate, LineEditDelegate
 from lisp.ui.qmodels import SimpleTableModel
 from lisp.ui.settings.settings_page import CueSettingsPage
 from lisp.ui.ui_utils import translate
+from lisp.ui.widgets.msc_groupbox import MscGroupBox
 
 
-class Msc(Midi):
+class Msc(Protocol):
     def __init__(self):
         super().__init__()
 
@@ -43,20 +46,94 @@ class Msc(Midi):
 
     def __new_message(self, message):
         if message.type == 'sysex':
-            self.protocol_event.emit(Midi.str_from_message(message))
+            print(Msc.str_from_message(message))
+            self.protocol_event.emit(Msc.str_from_message(message))
 
     @staticmethod
     def str_from_message(message):
-        return Midi.str_from_values(message.type, message.data)
+        return message.hex()
 
     @staticmethod
-    def str_from_values(m_type, data):
-        return '{} {}'.format(m_type, data)
+    def str_from_values(data):
+        # we use hex string for now, could be sysex data (as ints)
+        # msg = mido.parse([int(i, 16) for i in hex_str.split()])
+        return data
 
     @staticmethod
     def from_string(message_str):
-        m_type, data = message_str.split()
-        return m_type, data
+        # msg = mido.parse_string(message_str)
+        return message_str
+
+
+class MscMessageDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setLayout(QVBoxLayout())
+
+        self.mscGroup = MscGroupBox(self)
+        self.layout().addWidget(self.mscGroup)
+
+        self.buttons = QDialogButtonBox(self)
+        self.buttons.addButton(QDialogButtonBox.Cancel)
+        self.buttons.addButton(QDialogButtonBox.Ok)
+        self.layout().addWidget(self.buttons)
+
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+
+    def get_message(self):
+        return self.mscGroup.get_message()
+
+
+class MscCaptureDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setLayout(QVBoxLayout())
+
+        self.mscGroup = MscGroupBox(self)
+        self.layout().addWidget(self.mscGroup)
+
+        self.buttons = QDialogButtonBox(self)
+        self.buttons.addButton(QDialogButtonBox.Cancel)
+        self.buttons.addButton(QDialogButtonBox.Ok)
+        self.layout().addWidget(self.buttons)
+
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+
+    def get_message(self):
+        return self.mscGroup.get_message()
+
+    def add_message(self, message):
+        parser = MscParser(message)
+
+        if not parser.valid:
+            elogging.error("MscCue: could not parse MSC message")
+            return
+
+        self.mscGroup.device_id = parser.device_id
+        self.mscGroup.command_format = parser.command_format
+        self.mscGroup.command = parser.command
+
+        for msc_arg in MscArgument:
+            value = parser.get(msc_arg)
+            if value is not None:
+                if msc_arg is MscArgument.TIME_TYPE:
+                    pass
+                elif msc_arg is MscArgument.TIMECODE:
+                    self.mscGroup.set_argument(MscArgument.TIME_TYPE, parser[MscArgument.TIME_TYPE])
+                    self.mscGroup.set_argument(MscArgument.TIMECODE, value)
+                    self.mscGroup.checkbox_toggle(msc_arg, True)
+                    self.mscGroup.checkbox_enable(msc_arg, not parser.required(msc_arg))
+
+                else:
+                    self.mscGroup.set_argument(msc_arg, value)
+                    self.mscGroup.checkbox_toggle(msc_arg, True)
+                    self.mscGroup.checkbox_enable(msc_arg, not parser.required(msc_arg))
+            else:
+                self.mscGroup.checkbox_toggle(msc_arg, False)
 
 
 class MscSettings(CueSettingsPage):
@@ -67,31 +144,33 @@ class MscSettings(CueSettingsPage):
         self.setLayout(QVBoxLayout())
         self.layout().setAlignment(Qt.AlignTop)
 
-        self.midiGroup = QGroupBox(self)
-        self.midiGroup.setTitle(translate('ControllerMscSettings', 'MSC'))
-        # self.midiGroup.setEnabled(check_module('midi'))
-        self.midiGroup.setLayout(QGridLayout())
-        self.layout().addWidget(self.midiGroup)
+        self.msc_dialog = MscMessageDialog(self)
+        self.msc_capture_dialog = MscCaptureDialog(self)
 
-        self.midiModel = SimpleTableModel([
+        self.mscGroup = QGroupBox(self)
+        self.mscGroup.setTitle(translate('ControllerMscSettings', 'MSC'))
+        self.mscGroup.setLayout(QGridLayout())
+        self.layout().addWidget(self.mscGroup)
+
+        self.mscModel = SimpleTableModel([
             translate('ControllerMscSettings', 'MSC'),
             translate('ControllerMscSettings', 'Action')])
 
-        self.midiView = MscView(cue_class, parent=self.midiGroup)
-        self.midiView.setModel(self.midiModel)
-        self.midiGroup.layout().addWidget(self.midiView, 0, 0, 1, 2)
+        self.mscView = MscView(cue_class, parent=self.mscGroup)
+        self.mscView.setModel(self.mscModel)
+        self.mscGroup.layout().addWidget(self.mscView, 0, 0, 1, 2)
 
-        self.addButton = QPushButton(self.midiGroup)
+        self.addButton = QPushButton(self.mscGroup)
         self.addButton.clicked.connect(self.__new_message)
-        self.midiGroup.layout().addWidget(self.addButton, 1, 0)
+        self.mscGroup.layout().addWidget(self.addButton, 1, 0)
 
-        self.removeButton = QPushButton(self.midiGroup)
+        self.removeButton = QPushButton(self.mscGroup)
         self.removeButton.clicked.connect(self.__remove_message)
-        self.midiGroup.layout().addWidget(self.removeButton, 1, 1)
+        self.mscGroup.layout().addWidget(self.removeButton, 1, 1)
 
-        self.midiCapture = QPushButton(self.midiGroup)
-        self.midiCapture.clicked.connect(self.capture_message)
-        self.midiGroup.layout().addWidget(self.midiCapture, 2, 0)
+        self.mscCapture = QPushButton(self.mscGroup)
+        self.mscCapture.clicked.connect(self.capture_message)
+        self.mscGroup.layout().addWidget(self.mscCapture, 2, 0)
 
         self.retranslateUi()
 
@@ -100,22 +179,21 @@ class MscSettings(CueSettingsPage):
     def retranslateUi(self):
         self.addButton.setText(translate('ControllerSettings', 'Add'))
         self.removeButton.setText(translate('ControllerSettings', 'Remove'))
-        self.midiCapture.setText(translate('ControllerMscSettings', 'Capture'))
+        self.mscCapture.setText(translate('ControllerMscSettings', 'Capture'))
 
     def enable_check(self, enabled):
-        self.midiGroup.setCheckable(enabled)
-        self.midiGroup.setChecked(False)
+        self.mscGroup.setCheckable(enabled)
+        self.mscGroup.setChecked(False)
 
     def get_settings(self):
         settings = {}
-        checkable = self.midiGroup.isCheckable()
+        checkable = self.mscGroup.isCheckable()
 
-        if not (checkable and not self.midiGroup.isChecked()):
+        if not (checkable and not self.mscGroup.isChecked()):
             messages = []
 
-            for row in self.midiModel.rows:
-                message = Msc.str_from_values('sysex', row[0])
-                messages.append((message, row[-1]))
+            for row in self.mscModel.rows:
+                messages.append((row[0], row[1]))
 
             if messages:
                 settings['msc'] = messages
@@ -125,32 +203,32 @@ class MscSettings(CueSettingsPage):
     def load_settings(self, settings):
         if 'msc' in settings:
             for options in settings['msc']:
-                m_type, data = Msc.from_string(options[0])
-                self.midiModel.appendRow(data, options[1])
+                data = Msc.from_string(options[0])
+                self.mscModel.appendRow(data, options[1])
 
     def capture_message(self):
         handler = MIDIInput()
         handler.alternate_mode = True
         handler.new_message_alt.connect(self.__add_message)
 
-        QMessageBox.information(self, '',
-                                translate('ControllerMscSettings',
-                                          'Listening MSC messages ...'))
+        if self.msc_capture_dialog.exec_() == QDialog.Accepted:
+            msc = self.msc_capture_dialog.get_message()
+            self.mscModel.appendRow(msc.message.hex(), self._default_action)
 
         handler.new_message_alt.disconnect(self.__add_message)
         handler.alternate_mode = False
 
     def __add_message(self, msg):
-        if self.msgTypeCombo.currentData(Qt.UserRole) == msg.type:
-            self.midiModel.appendRow('',
-                                     self._default_action)
+        self.msc_capture_dialog.add_message(msg)
 
     def __new_message(self):
-        message_type = self.msgTypeCombo.currentData(Qt.UserRole)
-        self.midiModel.appendRow('', self._default_action)
+        if self.msc_dialog.exec_() == QDialog.Accepted:
+            msc = self.msc_dialog.get_message()
+            # parse back: mido.parse([int(i, 16) for i in hex_str.split()])
+            self.mscModel.appendRow(msc.message.hex(), self._default_action)
 
     def __remove_message(self):
-        self.midiModel.removeRow(self.midiView.currentIndex().row())
+        self.mscModel.removeRow(self.mscView.currentIndex().row())
 
 
 class MscView(QTableView):
@@ -158,7 +236,7 @@ class MscView(QTableView):
         super().__init__(**kwargs)
 
         self.delegates = [
-            LineEditDelegate(),
+            LineEditDelegate(read_only=True),
             CueActionDelegate(cue_class=cue_class,
                               mode=CueActionDelegate.Mode.Name)
         ]

--- a/lisp/plugins/controller/protocols/msc.py
+++ b/lisp/plugins/controller/protocols/msc.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Linux Show Player
+#
+# Copyright 2012-2016 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtCore import Qt, QT_TRANSLATE_NOOP
+from PyQt5.QtWidgets import QGroupBox, QPushButton, QComboBox, QVBoxLayout, \
+    QMessageBox, QTableView, QTableWidget, QHeaderView, QGridLayout
+
+from lisp.modules import check_module
+from lisp.modules.midi.midi_input import MIDIInput
+from lisp.plugins.controller.protocols.midi import Midi
+from lisp.ui.qdelegates import ComboBoxDelegate, SpinBoxDelegate, \
+    CueActionDelegate, LineEditDelegate
+from lisp.ui.qmodels import SimpleTableModel
+from lisp.ui.settings.settings_page import CueSettingsPage
+from lisp.ui.ui_utils import translate
+
+
+class Msc(Midi):
+    def __init__(self):
+        super().__init__()
+
+        if check_module('midi'):
+            midi_input = MIDIInput()
+            if not midi_input.is_open():
+                midi_input.open()
+            MIDIInput().new_message.connect(self.__new_message)
+
+    def __new_message(self, message):
+        if message.type == 'sysex':
+            self.protocol_event.emit(Midi.str_from_message(message))
+
+    @staticmethod
+    def str_from_message(message):
+        return Midi.str_from_values(message.type, message.data)
+
+    @staticmethod
+    def str_from_values(m_type, data):
+        return '{} {}'.format(m_type, data)
+
+    @staticmethod
+    def from_string(message_str):
+        m_type, data = message_str.split()
+        return m_type, data
+
+
+class MscSettings(CueSettingsPage):
+    Name = QT_TRANSLATE_NOOP('SettingsPageName', 'MSC Controls')
+
+    def __init__(self, cue_class, **kwargs):
+        super().__init__(cue_class, **kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+
+        self.midiGroup = QGroupBox(self)
+        self.midiGroup.setTitle(translate('ControllerMscSettings', 'MSC'))
+        # self.midiGroup.setEnabled(check_module('midi'))
+        self.midiGroup.setLayout(QGridLayout())
+        self.layout().addWidget(self.midiGroup)
+
+        self.midiModel = SimpleTableModel([
+            translate('ControllerMscSettings', 'MSC'),
+            translate('ControllerMscSettings', 'Action')])
+
+        self.midiView = MscView(cue_class, parent=self.midiGroup)
+        self.midiView.setModel(self.midiModel)
+        self.midiGroup.layout().addWidget(self.midiView, 0, 0, 1, 2)
+
+        self.addButton = QPushButton(self.midiGroup)
+        self.addButton.clicked.connect(self.__new_message)
+        self.midiGroup.layout().addWidget(self.addButton, 1, 0)
+
+        self.removeButton = QPushButton(self.midiGroup)
+        self.removeButton.clicked.connect(self.__remove_message)
+        self.midiGroup.layout().addWidget(self.removeButton, 1, 1)
+
+        self.midiCapture = QPushButton(self.midiGroup)
+        self.midiCapture.clicked.connect(self.capture_message)
+        self.midiGroup.layout().addWidget(self.midiCapture, 2, 0)
+
+        self.retranslateUi()
+
+        self._default_action = self._cue_class.CueActions[0].name
+
+    def retranslateUi(self):
+        self.addButton.setText(translate('ControllerSettings', 'Add'))
+        self.removeButton.setText(translate('ControllerSettings', 'Remove'))
+        self.midiCapture.setText(translate('ControllerMscSettings', 'Capture'))
+
+    def enable_check(self, enabled):
+        self.midiGroup.setCheckable(enabled)
+        self.midiGroup.setChecked(False)
+
+    def get_settings(self):
+        settings = {}
+        checkable = self.midiGroup.isCheckable()
+
+        if not (checkable and not self.midiGroup.isChecked()):
+            messages = []
+
+            for row in self.midiModel.rows:
+                message = Msc.str_from_values('sysex', row[0])
+                messages.append((message, row[-1]))
+
+            if messages:
+                settings['msc'] = messages
+
+        return settings
+
+    def load_settings(self, settings):
+        if 'msc' in settings:
+            for options in settings['msc']:
+                m_type, data = Msc.from_string(options[0])
+                self.midiModel.appendRow(data, options[1])
+
+    def capture_message(self):
+        handler = MIDIInput()
+        handler.alternate_mode = True
+        handler.new_message_alt.connect(self.__add_message)
+
+        QMessageBox.information(self, '',
+                                translate('ControllerMscSettings',
+                                          'Listening MSC messages ...'))
+
+        handler.new_message_alt.disconnect(self.__add_message)
+        handler.alternate_mode = False
+
+    def __add_message(self, msg):
+        if self.msgTypeCombo.currentData(Qt.UserRole) == msg.type:
+            self.midiModel.appendRow('',
+                                     self._default_action)
+
+    def __new_message(self):
+        message_type = self.msgTypeCombo.currentData(Qt.UserRole)
+        self.midiModel.appendRow('', self._default_action)
+
+    def __remove_message(self):
+        self.midiModel.removeRow(self.midiView.currentIndex().row())
+
+
+class MscView(QTableView):
+    def __init__(self, cue_class, **kwargs):
+        super().__init__(**kwargs)
+
+        self.delegates = [
+            LineEditDelegate(),
+            CueActionDelegate(cue_class=cue_class,
+                              mode=CueActionDelegate.Mode.Name)
+        ]
+
+        self.setSelectionBehavior(QTableWidget.SelectRows)
+        self.setSelectionMode(QTableView.SingleSelection)
+
+        self.setShowGrid(False)
+        self.setAlternatingRowColors(True)
+
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.horizontalHeader().setHighlightSections(False)
+
+        self.verticalHeader().sectionResizeMode(QHeaderView.Fixed)
+        self.verticalHeader().setDefaultSectionSize(24)
+        self.verticalHeader().setHighlightSections(False)
+
+        for column, delegate in enumerate(self.delegates):
+            self.setItemDelegateForColumn(column, delegate)

--- a/lisp/ui/qdelegates.py
+++ b/lisp/ui/qdelegates.py
@@ -115,11 +115,12 @@ class SpinBoxDelegate(QStyledItemDelegate):
 
 
 class LineEditDelegate(QStyledItemDelegate):
-    def __init__(self, max_length=-1, validator=None, **kwargs):
+    def __init__(self, max_length=-1, validator=None, read_only=False, **kwargs):
         super().__init__(**kwargs)
 
         self.max_length = max_length
         self.validator = validator
+        self.read_only = read_only
 
     def createEditor(self, parent, option, index):
         editor = QLineEdit(parent)
@@ -127,6 +128,8 @@ class LineEditDelegate(QStyledItemDelegate):
             editor.setMaxLength(self.max_length)
         if self.validator is not None:
             editor.setValidator(self.validator)
+        if self.read_only is True:
+            editor.setReadOnly(True)
         editor.setFrame(False)
 
         return editor

--- a/lisp/ui/widgets/msc_groupbox.py
+++ b/lisp/ui/widgets/msc_groupbox.py
@@ -271,7 +271,7 @@ class MscGroupBox(QGroupBox):
         self.__data_widgets[msc_arg][self.DATA_WIDGET].setEnabled(checked)
 
         if msc_arg is MscArgument.Q_LIST:
-            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
+            # self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
             self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setEnabled(checked)
 
         elif msc_arg is MscArgument.Q_PATH:

--- a/lisp/ui/widgets/msc_groupbox.py
+++ b/lisp/ui/widgets/msc_groupbox.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Linux Show Player
+#
+# Copyright 2017 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2017 Thomas Achtner <info@offtools.de>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+import functools
+
+from PyQt5.QtCore import QTime
+from PyQt5.QtWidgets import QGroupBox, QGridLayout, QLabel, \
+    QComboBox, QSpinBox, QDoubleSpinBox, QFrame, QCheckBox, QTimeEdit
+
+from lisp.ui.ui_utils import translate
+from lisp.modules.midi.midi_msc import MscMessage, MscCommand, \
+    MscCommandFormat, MscArgument, MscTimeType
+
+
+class MscGroupBox(QGroupBox):
+
+    DATA_WIDGET = 0
+    CHECK_WIDGET = 1
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setLayout(QGridLayout())
+        self.layout().setColumnStretch(0, 10)
+        self.layout().setColumnStretch(1, 10)
+        self.layout().setColumnStretch(2, 1)
+
+        # Device ID
+        self.__mscDeviceLabel = QLabel(self)
+        self.layout().addWidget(self.__mscDeviceLabel, 0, 0)
+        self.__mscDeviceSpin = QSpinBox(self)
+        self.__mscDeviceSpin.setRange(0, 127)
+        self.__mscDeviceSpin.setValue(0)
+        self.__mscDeviceSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscDeviceSpin, 0, 1, 1, 2)
+
+        self.__mscCmdFmtLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCmdFmtLabel, 1, 0)
+        self.__mscCmdFmtCombo = QComboBox(self)
+        self.__mscCmdFmtCombo.addItems([str(i) for i in MscCommandFormat])
+        self.__mscCmdFmtCombo.currentTextChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscCmdFmtCombo, 1, 1, 1, 2)
+
+        self.__mscCommandLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCommandLabel, 2, 0)
+        self.__mscCommandCombo = QComboBox(self)
+        self.__mscCommandCombo.addItems([str(i) for i in MscCommand])
+        self.__mscCommandCombo.currentTextChanged.connect(self.__type_changed)
+        self.__mscCommandCombo.currentTextChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscCommandCombo, 2, 1, 1, 2)
+
+        line = QFrame(self)
+        line.setFrameShape(QFrame.HLine)
+        line.setFrameShadow(QFrame.Sunken)
+        self.layout().addWidget(line, 3, 0, 1, 3)
+
+        # Data widgets
+        self.__data_widgets = {}
+
+        self.__mscQNumberLabel = QLabel(self)
+        self.layout().addWidget(self.__mscQNumberLabel, 4, 0)
+        self.__mscQNumberSpin = QDoubleSpinBox(self)
+        self.__mscQNumberSpin.setRange(0, 999)
+        self.__mscQNumberSpin.setDecimals(3)
+        self.__mscQNumberSpin.setSingleStep(1.0)
+        self.__mscQNumberSpin.setValue(0)
+        self.__mscQNumberSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscQNumberSpin, 4, 1)
+        self.__mscQNumberCheck = QCheckBox(self)
+        self.__mscQNumberCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_NUMBER))
+        self.layout().addWidget(self.__mscQNumberCheck, 4, 2)
+        self.__data_widgets[MscArgument.Q_NUMBER] = [self.__mscQNumberSpin, self.__mscQNumberCheck]
+
+        self.__mscQListLabel = QLabel(self)
+        self.layout().addWidget(self.__mscQListLabel, 5, 0)
+        self.__mscQListSpin = QDoubleSpinBox(self)
+        self.__mscQListSpin.setRange(0, 999)
+        self.__mscQListSpin.setDecimals(3)
+        self.__mscQListSpin.setSingleStep(1.0)
+        self.__mscQListSpin.setValue(0)
+        self.__mscQListSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscQListSpin, 5, 1)
+        self.__mscQListCheck = QCheckBox(self)
+        self.__mscQListCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_LIST))
+        self.layout().addWidget(self.__mscQListCheck, 5, 2)
+        self.__data_widgets[MscArgument.Q_LIST] = [self.__mscQListSpin, self.__mscQListCheck]
+
+        self.__mscQPathLabel = QLabel(self)
+        self.layout().addWidget(self.__mscQPathLabel, 6, 0)
+        self.__mscQPathSpin = QDoubleSpinBox(self)
+        self.__mscQPathSpin.setRange(0, 999)
+        self.__mscQPathSpin.setDecimals(3)
+        self.__mscQPathSpin.setSingleStep(1.0)
+        self.__mscQPathSpin.setValue(0)
+        self.__mscQPathSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscQPathSpin, 6, 1)
+        self.__mscQPathCheck = QCheckBox(self)
+        self.__mscQPathCheck.toggled.connect(functools.partial(self.__checked, MscArgument.Q_PATH))
+        self.layout().addWidget(self.__mscQPathCheck, 6, 2)
+        self.__data_widgets[MscArgument.Q_PATH] = [self.__mscQPathSpin, self.__mscQPathCheck]
+
+        self.__mscMacroLabel = QLabel(self)
+        self.layout().addWidget(self.__mscMacroLabel, 7, 0)
+        self.__mscMacroSpin = QSpinBox(self)
+        self.__mscMacroSpin.setRange(0, 127)
+        self.__mscMacroSpin.setValue(0)
+        self.__mscMacroSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscMacroSpin, 7, 1)
+        self.__mscMacroCheck = QCheckBox(self)
+        self.__mscMacroCheck.toggled.connect(functools.partial(self.__checked, MscArgument.MACRO_NUM))
+        self.layout().addWidget(self.__mscMacroCheck, 7, 2)
+        self.__data_widgets[MscArgument.MACRO_NUM] = [self.__mscMacroSpin, self.__mscMacroCheck]
+
+        self.__mscCtrlNumLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCtrlNumLabel, 8, 0)
+        self.__mscCtrlNumSpin = QSpinBox(self)
+        self.__mscCtrlNumSpin.setRange(0, 1023)
+        self.__mscCtrlNumSpin.setValue(0)
+        self.__mscCtrlNumSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscCtrlNumSpin, 8, 1)
+        self.__mscCtrlNumCheck = QCheckBox(self)
+        self.__mscCtrlNumCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_NUM))
+        self.layout().addWidget(self.__mscCtrlNumCheck, 8, 2)
+        self.__data_widgets[MscArgument.CTRL_NUM] = [self.__mscCtrlNumSpin, self.__mscCtrlNumCheck]
+
+        self.__mscCtrlValLabel = QLabel(self)
+        self.layout().addWidget(self.__mscCtrlValLabel, 9, 0)
+        self.__mscCtrlValSpin = QSpinBox(self)
+        self.__mscCtrlValSpin.setRange(0, 1023)
+        self.__mscCtrlValSpin.setValue(0)
+        self.__mscCtrlValSpin.valueChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscCtrlValSpin, 9, 1)
+        self.__mscCtrlValCheck = QCheckBox(self)
+        self.__mscCtrlValCheck.toggled.connect(functools.partial(self.__checked, MscArgument.CTRL_VALUE))
+        self.layout().addWidget(self.__mscCtrlValCheck, 9, 2)
+        self.__data_widgets[MscArgument.CTRL_VALUE] = [self.__mscCtrlValSpin, self.__mscCtrlValCheck]
+
+        self.__mscTimecodeLabel = QLabel(self)
+        self.layout().addWidget(self.__mscTimecodeLabel, 10, 0)
+        self.__mscTimecodeEdit = QTimeEdit(self)
+        self.__mscTimecodeEdit.setDisplayFormat('HH.mm.ss.zzz')
+        self.__mscTimecodeEdit.timeChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscTimecodeEdit, 10, 1)
+        self.__mscTimecodeCheck = QCheckBox(self)
+        self.__mscTimecodeCheck.toggled.connect(functools.partial(self.__checked, MscArgument.TIMECODE))
+        self.layout().addWidget(self.__mscTimecodeCheck, 10, 2)
+        self.__data_widgets[MscArgument.TIMECODE] = [self.__mscTimecodeEdit, self.__mscTimecodeCheck]
+
+        self.__mscTimeTypeLabel = QLabel(self)
+        self.layout().addWidget(self.__mscTimeTypeLabel, 11, 0)
+        self.__mscTimeTypeCombo = QComboBox(self)
+        self.__mscTimeTypeCombo.addItems([str(i) for i in MscTimeType])
+        self.__mscTimeTypeCombo.setCurrentText(str(MscTimeType.SMPTE))
+        self.__mscTimeTypeCombo.currentTextChanged.connect(self.__show_messsage)
+        self.layout().addWidget(self.__mscTimeTypeCombo, 11, 1)
+        self.__mscTimeTypeCheck = QCheckBox(self)
+        self.__mscTimeTypeCheck .toggled.connect(functools.partial(self.__checked, MscArgument.TIME_TYPE))
+        self.layout().addWidget(self.__mscTimeTypeCheck, 11, 2)
+        self.__data_widgets[MscArgument.TIME_TYPE] = [self.__mscTimeTypeCombo, self.__mscTimeTypeCheck]
+
+        self.__mscPreview = QLabel(self)
+        self.__mscPreview.setStyleSheet('font: bold')
+        self.__mscPreview.setMinimumHeight(50)
+        self.layout().addWidget(self.__mscPreview, 13, 0, 1, 2)
+
+        self.__retranslateUi()
+
+        self.__mscCommandCombo.currentTextChanged.emit(str(MscCommand.GO))
+
+    @property
+    def device_id(self):
+        return self.__mscDeviceSpin.value()
+
+    @device_id.setter
+    def device_id(self, device_id):
+        self.__mscDeviceSpin.setValue(device_id)
+
+    @property
+    def command_format(self):
+        return MscCommandFormat(self.__mscCmdFmtCombo.currentTextChanged())
+
+    @command_format.setter
+    def command_format(self, command_format):
+        self.__mscCmdFmtCombo.setCurrentText(str(command_format))
+
+    @property
+    def command(self):
+        return MscCommand(self.__mscCommandCombo.currentText())
+
+    @command.setter
+    def command(self, command):
+        self.__mscCommandCombo.setCurrentText(str(command))
+
+    def get_argument_widget(self, msc_arg):
+        return self.__data_widgets[msc_arg][self.DATA_WIDGET]
+
+    def set_argument(self, msc_arg, arg):
+        if msc_arg is MscArgument.TIME_TYPE:
+            if not isinstance(arg, MscTimeType):
+                raise ValueError("not an MscTimeType")
+            self.__data_widgets[msc_arg][self.DATA_WIDGET].setCurrentText(str(arg))
+        elif msc_arg is MscArgument.TIMECODE:
+            if not isinstance(arg, int) and arg < 0:
+                raise ValueError("not an int")
+            self.__data_widgets[msc_arg][self.DATA_WIDGET].setTime(QTime().fromMSecsSinceStartOfDay(arg))
+
+        else:
+            if not isinstance(arg, (int, float)) and arg < 0:
+                raise ValueError("not an int or float")
+            self.__data_widgets[msc_arg][self.DATA_WIDGET].setValue(arg)
+
+    def checkbox_enable(self, msc_arg, enable):
+        self.__data_widgets[msc_arg][self.CHECK_WIDGET].setEnabled(enable)
+
+    def checkbox_toggle(self, msc_arg, checked):
+        self.__data_widgets[msc_arg][self.CHECK_WIDGET].setChecked(checked)
+
+    def __retranslateUi(self):
+        self.setTitle(translate('MSCSettings', 'MSC Message'))
+        self.__mscDeviceLabel.setText(translate('MSCSettings', 'Device ID'))
+        self.__mscCmdFmtLabel.setText(translate('MSCSettings', 'Command Format'))
+        self.__mscCommandLabel.setText(translate('MSCSettings', 'MSC Command'))
+        self.__mscQNumberLabel.setText(translate('MSCSettings', 'Q_Number'))
+        self.__mscQListLabel.setText(translate('MSCSettings', 'Q_List'))
+        self.__mscQPathLabel.setText(translate('MSCSettings', 'Q_Path'))
+        self.__mscMacroLabel.setText(translate('MSCSettings', 'Macro Number'))
+        self.__mscCtrlNumLabel.setText(translate('MSCSettings', 'Generic Control  Number'))
+        self.__mscCtrlValLabel.setText(translate('MSCSettings', 'Generic Control  Value'))
+        self.__mscTimecodeLabel.setText(translate('MSCSettings', 'Timecode'))
+
+    def get_message(self):
+        device_id = self.__mscDeviceSpin.value()
+        command = MscCommand(self.__mscCommandCombo.currentText())
+        command_format = MscCommandFormat(self.__mscCmdFmtCombo.currentText())
+
+        message = MscMessage(device_id, command_format, command)
+
+        for msc_arg in MscMessage.get_arguments(command):
+            if self.__data_widgets[msc_arg][self.CHECK_WIDGET].isChecked():
+                if msc_arg is MscArgument.TIME_TYPE:
+                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].currentText()
+                elif msc_arg is MscArgument.TIMECODE:
+                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].time().msecsSinceStartOfDay()
+                else:
+                    message[msc_arg] = self.__data_widgets[msc_arg][self.DATA_WIDGET].value()
+
+        return message
+
+    def __show_messsage(self):
+        message = self.get_message()
+        self.__mscPreview.setText('MSC:  {0}'.format(message.to_hex_str()))
+
+    def __checked(self, msc_arg, checked):
+        self.__data_widgets[msc_arg][self.DATA_WIDGET].setEnabled(checked)
+
+        if msc_arg is MscArgument.Q_LIST:
+            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setChecked(checked)
+            self.__data_widgets[MscArgument.Q_PATH][self.CHECK_WIDGET].setEnabled(checked)
+
+        elif msc_arg is MscArgument.Q_PATH:
+            self.__data_widgets[MscArgument.Q_LIST][self.CHECK_WIDGET].setEnabled(not checked)
+
+        elif msc_arg is MscArgument.TIMECODE:
+            self.__data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setChecked(checked)
+
+        elif msc_arg is MscArgument.TIME_TYPE:
+            self.__data_widgets[MscArgument.TIME_TYPE][self.CHECK_WIDGET].setEnabled(False)
+
+        self.__show_messsage()
+
+    def __type_changed(self, cmd_str):
+        cmd = MscCommand(cmd_str)
+        args = MscMessage.get_arguments(cmd)
+        for key, widgets in self.__data_widgets.items():
+            if key in args:
+                if args[key] is cmd:
+                    widgets[self.CHECK_WIDGET].setChecked(True)
+                    widgets[self.CHECK_WIDGET].setEnabled(False)
+                elif key is MscArgument.TIME_TYPE:
+                    pass
+                else:
+                    widgets[self.CHECK_WIDGET].setChecked(True)
+                    widgets[self.CHECK_WIDGET].setEnabled(True)
+            else:
+                widgets[1].setChecked(False)
+                widgets[1].setEnabled(False)
+                widgets[0].setEnabled(False)


### PR DESCRIPTION
this adds MSC (Midi Show Control) to Action Cues and to the Cue Controller Protocols.
*MscMessage: write MSC messages
*MscParser: parse MSC messages
*session wide MSC Input is skipped for now (REST API)
*Keys are stored in hex sequence strings, like F0 7F 00 02 01 01 33 00 32 F7 (Generic Lighting, GO, Cue 3 Q_List 2), because they are easier to read, then the data fields of a mido sysex message.
Also most of hardware manufacturers of lighting equipment refer to these kind of notation.