### PR TITLE
Fix compatibility with Python 3.7, async is now a reserved word

### DIFF
--- a/lisp/core/decorators.py
+++ b/lisp/core/decorators.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 #
 # This file is part of Linux Show Player
@@ -23,7 +24,7 @@ from functools import wraps, partial
 from threading import Thread, Lock, RLock
 
 
-def async(target):
+def async_function(target):
     """Decorator. Make a function asynchronous.
 
     The decorated function is executed in a differed thread.

--- a/lisp/core/signal.py
+++ b/lisp/core/signal.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 #
 # This file is part of Linux Show Player
@@ -28,7 +29,7 @@ from types import MethodType, BuiltinMethodType
 from PyQt5.QtCore import QEvent, QObject
 from PyQt5.QtWidgets import QApplication
 
-from lisp.core.decorators import async
+from lisp.core.decorators import async_function
 from lisp.core.util import weak_call_proxy
 
 __all__ = ['Signal', 'Connection']
@@ -84,7 +85,7 @@ class Slot:
 class AsyncSlot(Slot):
     """Asynchronous slot, NOT queued, any call is performed in a new thread."""
 
-    @async
+    @async_function
     def call(self, *args, **kwargs):
         super().call(*args, **kwargs)
 

--- a/lisp/cues/cue.py
+++ b/lisp/cues/cue.py
@@ -21,7 +21,7 @@ from threading import Lock
 from uuid import uuid4
 
 from lisp.core.configuration import config
-from lisp.core.decorators import async
+from lisp.core.decorators import async_function
 from lisp.core.fade_functions import FadeInType, FadeOutType
 from lisp.core.has_properties import HasProperties, Property, WriteOnceProperty
 from lisp.core.rwait import RWait
@@ -206,7 +206,7 @@ class Cue(HasProperties):
                 fade_type = FadeInType[config['Cue'].get('FadeActionType')]
                 self.fadein(duration, fade_type)
 
-    @async
+    @async_function
     def start(self, fade=False):
         """Start the cue."""
 
@@ -292,7 +292,7 @@ class Cue(HasProperties):
         """
         return False
 
-    @async
+    @async_function
     def stop(self, fade=False):
         """Stop the cue."""
 
@@ -350,7 +350,7 @@ class Cue(HasProperties):
         """
         return False
 
-    @async
+    @async_function
     def pause(self, fade=False):
         """Pause the cue."""
 
@@ -404,7 +404,7 @@ class Cue(HasProperties):
         """
         return False
 
-    @async
+    @async_function
     def interrupt(self, fade=False):
         """Interrupt the cue.
 

--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -22,7 +22,7 @@ from threading import Lock
 from PyQt5.QtCore import QT_TRANSLATE_NOOP
 
 from lisp.core.configuration import config
-from lisp.core.decorators import async
+from lisp.core.decorators import async_function
 from lisp.core.fade_functions import FadeInType, FadeOutType
 from lisp.core.fader import Fader
 from lisp.core.has_properties import NestedProperties
@@ -113,7 +113,7 @@ class MediaCue(Cue):
 
         self.media.interrupt()
 
-    @async
+    @async_function
     def fadein(self, duration, fade_type):
         if not self._st_lock.acquire(timeout=0.1):
             return
@@ -131,7 +131,7 @@ class MediaCue(Cue):
 
         self._st_lock.release()
 
-    @async
+    @async_function
     def fadeout(self, duration, fade_type):
         if not self._st_lock.acquire(timeout=0.1):
             return
@@ -198,7 +198,7 @@ class MediaCue(Cue):
     def _can_fade(self, duration):
         return self.__volume is not None and duration > 0
 
-    @async
+    @async_function
     def _on_start_fade(self):
         if self.__volume is not None:
             self.__fadein(self.fadein_duration,

--- a/lisp/modules/action_cues/command_cue.py
+++ b/lisp/modules/action_cues/command_cue.py
@@ -22,7 +22,7 @@ import subprocess
 from PyQt5.QtCore import Qt, QT_TRANSLATE_NOOP
 from PyQt5.QtWidgets import QVBoxLayout, QGroupBox, QLineEdit, QCheckBox
 
-from lisp.core.decorators import async
+from lisp.core.decorators import async_function
 from lisp.core.has_properties import Property
 from lisp.cues.cue import Cue, CueState, CueAction
 from lisp.ui.settings.cue_settings import CueSettingsRegistry
@@ -55,7 +55,7 @@ class CommandCue(Cue):
         self.__exec_command()
         return True
 
-    @async
+    @async_function
     def __exec_command(self):
         if not self.command.strip():
             return

--- a/lisp/modules/action_cues/volume_control.py
+++ b/lisp/modules/action_cues/volume_control.py
@@ -1,3 +1,4 @@
+
 # -*- coding: utf-8 -*-
 #
 # This file is part of Linux Show Player
@@ -25,7 +26,7 @@ from PyQt5.QtWidgets import QVBoxLayout, QLabel, QHBoxLayout, QGroupBox, \
 from lisp.application import Application
 from lisp.backend.audio_utils import MIN_VOLUME_DB, MAX_VOLUME_DB, \
     linear_to_db, db_to_linear
-from lisp.core.decorators import async
+from lisp.core.decorators import async_function
 from lisp.core.fade_functions import FadeInType, FadeOutType
 from lisp.core.fader import Fader
 from lisp.core.has_properties import Property
@@ -96,7 +97,7 @@ class VolumeControl(Cue):
 
     __interrupt__ = __stop__
 
-    @async
+    @async_function
     def __fade(self, fade_type):
         try:
             self.__fader.prepare()

--- a/lisp/modules/remote/controller.py
+++ b/lisp/modules/remote/controller.py
@@ -23,7 +23,7 @@ from http.client import HTTPConnection
 from xmlrpc.client import ServerProxy, Fault, Transport
 from xmlrpc.server import SimpleXMLRPCServer
 
-from lisp.core.decorators import async
+from lisp.core.decorators import async_function
 from lisp.core.singleton import Singleton
 from lisp.modules.remote.discovery import Announcer
 from lisp.modules.remote.dispatcher import RemoteDispatcher
@@ -60,7 +60,7 @@ class RemoteController(metaclass=Singleton):
         self.server.register_introspection_functions()
         self.server.register_instance(RemoteDispatcher())
 
-    @async
+    @async_function
     def start(self):
         logging.info('REMOTE: Session started at ' +
                      str(self.server.server_address))


### PR DESCRIPTION
This closes #126 