### PR TITLE
Fix crash when editing a MIDI cue a second time

### DIFF
--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -19,21 +19,12 @@
 
 import mido
 
-
 def str_msg_to_dict(str_message):
-    message = mido.parse_string(str_message)
-    dict_msg = {'type': message.type}
-
-    for name in message._spec.arguments:
-        dict_msg[name] = getattr(message, name)
-
-    return dict_msg
+    return mido.parse_string(str_message).dict()
 
 
 def dict_msg_to_str(dict_message):
-    msg_type = dict_message.pop('type')
-    message = mido.Message(msg_type, **dict_message)
-
+    message = mido.Message.from_dict(dict_message)
     return mido.format_as_string(message, include_time=False)
 
 


### PR DESCRIPTION
Currently, when using the `develop` branch, attempting to edit an already edited MIDI cue causes `lisp` to crash.

(Note: This was fixed for the `v0.5.1` release in 20bb7a2, albeit with a different solution. It appears that that fix was not migrated to the `develop` branch.)

Steps to reproduce:
* Open `lisp` (either layout).
* Create a MIDI Cue.
* Use appropriate action to open the edit dialog.
* Press "OK" (Don't have to make any actual edits) to save and close the dialog.
* Re-open the dialog.
* Observe the crash.

The crash occurs because `_spec` is not a property of `mido`'s `Message` class.

The fix in this PR changes `str_msg_to_dict` to use `mido`'s methods to convert from `str` to `dict`, rather than trying to duplicate functionality.

(PR also includes a clean-up of the companion function `dict_msg_to_str`)