### PR TITLE
Set volume in the case of no fade-up

### DIFF
--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -64,15 +64,14 @@ class MediaCue(Cue):
     def __start__(self, fade=False):
         if fade and self._can_fade(self.fadein_duration):
             self.__volume.current_volume = 0
+        else:
+            # If we know there won't be a fade-in: restore the volume,
+            # just in case we're resuming after a fade-out-and-pause.
+            self.__volume.current_volume = self.__volume.volume
 
         self.media.play()
         if fade:
             self._on_start_fade()
-
-        # If there was a fade-down, but there wasn't a fade-up - either
-        # because the fade-up was disabled, or because it had a duration
-        # of zero - restore the volume.
-        self.__volume.current_volume = self.__volume.volume
 
         return True
 

--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -69,6 +69,11 @@ class MediaCue(Cue):
         if fade:
             self._on_start_fade()
 
+        # If there was a fade-down, but there wasn't a fade-up - either
+        # because the fade-up was disabled, or because it had a duration
+        # of zero - restore the volume.
+        self.__volume.current_volume = self.__volume.volume
+
         return True
 
     def __stop__(self, fade=False):


### PR DESCRIPTION
When the fade-down duration of a media cue is > 0, and either:
* The fade-up duration is 0; or
* The resume-button is set to resume (instead of resume-and-fade-up) in the preferences

Then:
* Pausing will fade-down and pause track
* Resuming again will resume playback, but not restore volume

This changeset fixes that (for the `master` branch). (The `develop` branch suffers from the same problem, so I don't know if you wish to also apply this patch to that, or something else. You're the boss :wink:)