### PR TITLE
Follow XDG spec when storing user data.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+appdirs = ">=1.4.1"
 Cython = "~=0.29"
 falcon = "~=1.4"
 JACK-Client = "~=0.4"

--- a/lisp/__init__.py
+++ b/lisp/__init__.py
@@ -27,7 +27,8 @@ __version__ = "0.6.0.dev0"
 # Application wide "constants"
 APP_DIR = path.dirname(__file__)
 
-USER_DIRS = AppDirs("linux_show_player", __author__)
+# The version passed follows <major>.<minor>
+USER_DIRS = AppDirs("LinuxShowPlayer", version=".".join(__version__.split(".")[0:2]))
 
 DEFAULT_APP_CONFIG = path.join(APP_DIR, "default.json")
 USER_APP_CONFIG = path.join(USER_DIRS.user_config_dir, "lisp.json")

--- a/lisp/__init__.py
+++ b/lisp/__init__.py
@@ -16,6 +16,7 @@
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
 from os import path
+from appdirs import AppDirs
 
 __author__ = "Francesco Ceruti"
 __email__ = "ceppofrancy@gmail.com"
@@ -26,12 +27,10 @@ __version__ = "0.6.0.dev0"
 # Application wide "constants"
 APP_DIR = path.dirname(__file__)
 
-USER_DIR = path.join(path.expanduser("~"), ".linux_show_player")
-
-LOGS_DIR = path.join(USER_DIR, "logs")
+USER_DIRS = AppDirs("linux_show_player", __author__)
 
 DEFAULT_APP_CONFIG = path.join(APP_DIR, "default.json")
-USER_APP_CONFIG = path.join(USER_DIR, "lisp.json")
+USER_APP_CONFIG = path.join(USER_DIRS.user_config_dir, "lisp.json")
 
 I18N_PATH = path.join(APP_DIR, "i18n", "qm")
 

--- a/lisp/main.py
+++ b/lisp/main.py
@@ -27,12 +27,11 @@ from PyQt5.QtCore import QLocale, QLibraryInfo
 from PyQt5.QtWidgets import QApplication
 
 from lisp import (
-    USER_DIR,
+    USER_DIRS,
     DEFAULT_APP_CONFIG,
     USER_APP_CONFIG,
     plugins,
     I18N_PATH,
-    LOGS_DIR,
 )
 from lisp.application import Application
 from lisp.core.configuration import JSONFileConfiguration
@@ -63,8 +62,9 @@ def main():
 
     args = parser.parse_args()
 
-    # Make sure the application user directory exists
-    os.makedirs(USER_DIR, exist_ok=True)
+    # Make sure the application user directories exist
+    os.makedirs(USER_DIRS.user_config_dir, exist_ok=True)
+    os.makedirs(USER_DIRS.user_data_dir, exist_ok=True)
 
     # Get logging level for the console
     if args.log == "debug":
@@ -93,10 +93,10 @@ def main():
     root_logger.addHandler(stream_handler)
 
     # Make sure the logs directory exists
-    os.makedirs(LOGS_DIR, exist_ok=True)
+    os.makedirs(USER_DIRS.user_log_dir, exist_ok=True)
     # Create the file handler
     file_handler = RotatingFileHandler(
-        os.path.join(LOGS_DIR, "lisp.log"),
+        os.path.join(USER_DIRS.user_log_dir, "lisp.log"),
         maxBytes=10 * (2 ** 20),
         backupCount=5,
     )

--- a/lisp/plugins/__init__.py
+++ b/lisp/plugins/__init__.py
@@ -19,7 +19,7 @@ import inspect
 import logging
 from os import path
 
-from lisp import USER_DIR
+from lisp import USER_DIRS
 from lisp.core.configuration import JSONFileConfiguration
 from lisp.core.loading import load_classes
 from lisp.ui.ui_utils import install_translation, translate
@@ -52,7 +52,7 @@ def load_plugins(application):
 
             # Load plugin configuration
             config = JSONFileConfiguration(
-                path.join(USER_DIR, mod_name + ".json"), default_config_path
+                path.join(USER_DIRS.user_config_dir, mod_name + ".json"), default_config_path
             )
             plugin.Config = config
 

--- a/lisp/plugins/presets/lib.py
+++ b/lisp/plugins/presets/lib.py
@@ -19,11 +19,11 @@ import json
 import os
 from zipfile import ZipFile, BadZipFile
 
-from lisp import USER_DIR
+from lisp import USER_DIRS
 from lisp.core.actions_handler import MainActionsHandler
 from lisp.cues.cue_actions import UpdateCueAction, UpdateCuesAction
 
-PRESETS_DIR = os.path.join(USER_DIR, "presets")
+PRESETS_DIR = os.path.join(USER_DIRS.user_data_dir, "presets")
 
 
 def preset_path(name):


### PR DESCRIPTION
On Linux systems, it is generally recommended to follow the [XDG specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) when determining where to store user configuration, file-level caches, and user-specific application data.

Thus, as of this PR:
* *configuration* is now stored at `$XDG_CONFIG_HOME/linux_show_player`
    (by default: `~/.config/linux_show_player`)
* *presets* are now stored under `$XDG_DATA_HOME/linux_show_player/presets`
    (by default: `~/.local/share/linux_show_player/presets`)
* *logs* are now stored under `$XDG_CACHE_HOME/linux_show_player/logs`
    (by default: `~/.cache/linux_show_player/logs`)

On the downside, this PR does add another python dependency. However, the advantage of using the `appdirs` python module (instead of hard-coding the `~/.{config|share|cache}`paths) is:
1) We follow the `$XDG_{*}_HOME` environment values, should a user have them set;
2) If the standard ever changes, then we don't have to worry about it;
3) If *lisp* is ever ported to Windows or OSX, then the module provides suitable paths for those OSes;