### PR TITLE
Minor changes: Return to player if the user don't save and add shortcut to remove cue

### DIFF
--- a/lisp/layout/cue_layout.py
+++ b/lisp/layout/cue_layout.py
@@ -218,6 +218,9 @@ class CueLayout(HasProperties):
     def finalize(self):
         """Destroy all the layout elements"""
 
+    def _remove_cue(self, cue):
+        self.cue_model.remove(cue)
+
     def _remove_cues(self, cues):
         for cue in cues:
             self.cue_model.remove(cue)

--- a/lisp/plugins/list_layout/layout.py
+++ b/lisp/plugins/list_layout/layout.py
@@ -251,7 +251,7 @@ class ListLayout(CueLayout):
             if QKeySequence(keys) in self._go_key_sequence:
                 event.accept()
                 self.__go_slot()
-            elif event.key() == Qt.Key_Backspace:
+            elif event.key() == Qt.Key_Delete:
                 cue = self.standby_cue()
                 if cue is not None:
                     self._remove_cue(cue)

--- a/lisp/plugins/list_layout/layout.py
+++ b/lisp/plugins/list_layout/layout.py
@@ -251,6 +251,10 @@ class ListLayout(CueLayout):
             if QKeySequence(keys) in self._go_key_sequence:
                 event.accept()
                 self.__go_slot()
+            elif event.key() == Qt.Key_Backspace:
+                cue = self.standby_cue()
+                if cue is not None:
+                    self._remove_cue(cue)
             elif event.key() == Qt.Key_Space:
                 if event.modifiers() == Qt.ShiftModifier:
                     event.accept()

--- a/lisp/ui/mainwindow.py
+++ b/lisp/ui/mainwindow.py
@@ -289,11 +289,10 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
 
     def _save(self):
         if self.session.session_file == "":
-            saved = self._save_with_name()
-
-        if saved:
+            return self._save_with_name()
+        else:
             self.save_session.emit(self.session.session_file)
-        return saved
+            return True
 
     def _save_with_name(self):
         filename, ok = QFileDialog.getSaveFileName(
@@ -306,7 +305,6 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
 
             self.save_session.emit(filename)
             return True
-
         else:
             return False
 

--- a/lisp/ui/mainwindow.py
+++ b/lisp/ui/mainwindow.py
@@ -289,9 +289,11 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
 
     def _save(self):
         if self.session.session_file == "":
-            self._save_with_name()
-        else:
+            saved = self._save_with_name()
+
+        if saved:
             self.save_session.emit(self.session.session_file)
+        return saved
 
     def _save_with_name(self):
         filename, ok = QFileDialog.getSaveFileName(
@@ -303,6 +305,10 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
                 filename += ".lsp"
 
             self.save_session.emit(filename)
+            return True
+
+        else:
+            return False
 
     def _show_preferences(self):
         prefUi = AppConfigurationDialog(parent=self)
@@ -341,7 +347,7 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
             if result == QMessageBox.Cancel:
                 return False
             elif result == QMessageBox.Save:
-                self._save()
+                return self._save()
 
         return True
 


### PR DESCRIPTION
Hello, 
1) I detect a minor problem when I want to save a file. 
Indeed, when I close the session and I don't save the session, a message box is activated (with 3 options: "Close without Saving", "Cancel" and "Save"). If I click in "Save" (it opens a widget with all my directories and files) and close by mistake the widget, I quit the application. However, I think it will be better if we close by mistake (and so we don't save anything), we should be redirected on the app.

2) Morever, I notice also that there is no shortcut to remove a cue. So I decided to put it (I hope it will be useful because it's an action that I use regularly).

Here are some pictures of the problem (for the first problem):
![message-box](https://user-images.githubusercontent.com/35834540/52157546-1c182000-2690-11e9-825d-8574cdb49c93.png)
![cancel](https://user-images.githubusercontent.com/35834540/52157551-21756a80-2690-11e9-9fa3-8701116c1ca8.png)
 
I hope I worked on the correct branch this time. To be honest, it was not intentional to fix two issues on the same pull request (save and shortcut), I would have preferred to make a pull request for each issue but I made a little mistake (I'am extremely sorry if it bothers you) 