### PR TITLE
Correct the Cart Layout's page_widget::indexAt method

### DIFF
--- a/lisp/plugins/cart_layout/page_widget.py
+++ b/lisp/plugins/cart_layout/page_widget.py
@@ -112,15 +112,14 @@ class CartPageWidget(QWidget):
                 self.copyWidgetRequested.emit(event.source(), row, column)
 
     def indexAt(self, pos):
-        # Margins and spacings are equals
-        space = self.layout().horizontalSpacing()
+        # All four margins (left, right, top, bottom) of a cue widget are equal
         margin = self.layout().contentsMargins().right()
 
-        r_size = (self.height() + margin * 2) // self.__rows + space
-        c_size = (self.width() + margin * 2) // self.__columns + space
+        r_size = (self.height() + margin * 2) // self.__rows
+        c_size = (self.width() + margin * 2) // self.__columns
 
-        row = math.ceil(pos.y() / r_size) - 1
-        column = math.ceil(pos.x() / c_size) - 1
+        row = math.floor(pos.y() / r_size)
+        column = math.floor(pos.x() / c_size)
 
         return row, column
 


### PR DESCRIPTION
The code was incorrectly calculating the size of cue-widgets on a page.

This is observable by:
1. Create a new showfile using the Cart Layout.
2. Create a cue (any type) and place it in the bottom-right of the tab page.
3. Right-click somewhere in the lower-right quadrant of the cue-widget.
4. Close the resulting context menu.
5. Right click somewhere around or on the coloured dot in the top left of the cue-widget.
6. Observe the application crash to desktop

Why? After calculating the correct width and height, the code was then adding the value of the variable `space` (six pixels on my system) to both calculated dimensions. As the cue-widgets are placed further and further away from position `(0, 0)`, there is an ever-increasing margin where the top and left sides of a cue-widget are resolved by the `indexAt` method to be either the cue-widget to the left or above the one the cursor is actually over.

With the default 7x5 grid, the bottom-left most cue has a 42-pixel wide margin along its left side and a 30-pixel-high margin along its top side where the `indexAt` returns the grid id of the cue either to the left or above it.

In the case that there *is* an actual cue to the left or above, then the user gets the context menu for that cue instead of the one underneath the cursor.

In the above case where there is no cue either to the left or above the cue, `NoneType` instead of a cue-widget is found at the calculated grid-reference, causing a fatal error when this `NoneType` is then asked for a property it does not possess.