### PR TITLE
Potential fix for issue 180

### DIFF
--- a/lisp/plugins/list_layout/list_view.py
+++ b/lisp/plugins/list_layout/list_view.py
@@ -195,7 +195,8 @@ class CueListView(QTreeWidget):
     def __currentItemChanged(self, current, previous):
         if previous is not None:
             previous.current = False
-            self.__updateItemStyle(previous)
+            if self.itemWidget(previous, 0):
+                self.__updateItemStyle(previous)
 
         if current is not None:
             current.current = True
@@ -249,6 +250,7 @@ class CueListView(QTreeWidget):
         item = self.takeTopLevelItem(before)
         self.insertTopLevelItem(after, item)
         self.__setupItemWidgets(item)
+        self.__updateItemStyle(item)
 
     def __cueRemoved(self, cue):
         cue.property_changed.disconnect(self.__cuePropChanged)


### PR DESCRIPTION
(Should fix #180, caused by changes in fd883a43.)

For some reason the `QTreeWidgetItem` passed as `previous` to `__currentItemChanged` retains its former index (despite the fact that logically, by the time the method is called, a different `QTreeWidgetItem` should reside there now) but appears to have lost its references to its "column widgets".

Thus, when we request each of the "column widgets" in turn, they can't be found.

When removing a row, we don't really need to set the styles of a `QTreeWidgetItem` that's being removed... so let's not.

As to moving a row, the `QTreeWidgetItem` returned by `self.takeTopLevelItem` in `__cueMoved` has the "column widgets" we're looking for. So let's apply `__updateItemStyle` on that instead.