### PR TITLE
Remove backslash from end of last line

### DIFF
--- a/lisp/ui/ui_utils.py
+++ b/lisp/ui/ui_utils.py
@@ -101,4 +101,4 @@ def tr_sorted(context, iterable, key=None, reverse=False):
         def tr_key(item):
             translate(context, item)
 
-    return sorted(iterable, key=tr_key, reverse=reverse)\
+    return sorted(iterable, key=tr_key, reverse=reverse)


### PR DESCRIPTION
The extra backslash leads to a `SyntaxError`  when compiling the module to byte-code (Python 3.8):

```
writing byte-compilation script '/home/chris/tmp/tmpzjp2l7dq.py'
/usr/bin/python /home/chris/tmp/tmpzjp2l7dq.py
  File "usr/lib/python3.8/site-packages/lisp/ui/ui_utils.py", line 104
    return sorted(iterable, key=tr_key, reverse=reverse)\
                                                        ^
SyntaxError: unexpected EOF while parsing

removing /home/chris/tmp/tmpzjp2l7dq.py
```