### PR TITLE
allow config to disable go key while playing

### DIFF
--- a/lisp/default.cfg
+++ b/lisp/default.cfg
@@ -55,6 +55,7 @@ ShowPlaying = True
 AutoContinue = True
 EndList = Stop
 GoKey = Space
+DisableGoKeyWhilePlaying = False
 StopCueFade = True
 PauseCueFade = True
 ResumeCueFade = True

--- a/lisp/layouts/list_layout/layout.py
+++ b/lisp/layouts/list_layout/layout.py
@@ -87,6 +87,7 @@ class ListLayout(QWidget, CueLayout):
         self._go_key = config['ListLayout']['GoKey']
         self._go_key_sequence = QKeySequence(self._go_key,
                                              QKeySequence.NativeText)
+        self._disable_go_while_playing = config['ListLayout'].getboolean('DisableGoKeyWhilePlaying')
 
         try:
             self._end_list = EndListBehavior(config['ListLayout']['EndList'])
@@ -275,7 +276,10 @@ class ListLayout(QWidget, CueLayout):
                 keys += Qt.META
 
             if QKeySequence(keys) in self._go_key_sequence:
-                self.go()
+                if self.playView.has_running_cues() is not True:
+                    self.go()
+                elif (self._disable_go_while_playing is not True):
+                    self.go()
             elif e.key() == Qt.Key_Space:
                 if qApp.keyboardModifiers() == Qt.ShiftModifier:
                     cue = self.current_cue()

--- a/lisp/layouts/list_layout/list_layout_settings.py
+++ b/lisp/layouts/list_layout/list_layout_settings.py
@@ -76,6 +76,9 @@ class ListLayoutSettings(SettingsPage):
         self.goKeyLayout.setStretch(0, 2)
         self.goKeyLayout.setStretch(1, 5)
 
+        self.disableGoKeyWhilePlaying = QCheckBox(self.behaviorsGroup)
+        self.behaviorsGroup.layout().addWidget(self.disableGoKeyWhilePlaying)
+        
         self.useFadeGroup = QGroupBox(self)
         self.useFadeGroup.setLayout(QGridLayout())
         self.layout().addWidget(self.useFadeGroup)
@@ -112,6 +115,7 @@ class ListLayoutSettings(SettingsPage):
         self.autoNext.setText(translate('ListLayout', 'Auto-select next cue'))
         self.endListLabel.setText(translate('ListLayout', 'At list end:'))
         self.goKeyLabel.setText(translate('ListLayout', 'Go key:'))
+        self.disableGoKeyWhilePlaying.setText(translate('ListLayout', 'Disable Go key while cues are playing (the button can still be clicked)'))
 
         self.useFadeGroup.setTitle(translate('ListLayout', 'Use fade'))
         self.stopCueFade.setText(translate('ListLayout', 'Stop Cue'))
@@ -133,6 +137,7 @@ class ListLayoutSettings(SettingsPage):
             'endlist': str(self.endListBehavior.currentData()),
             'gokey': self.goKeyEdit.keySequence().toString(
                 QKeySequence.NativeText),
+            'disablegokeywhileplaying': str(self.disableGoKeyWhilePlaying.isChecked()),
             'stopcuefade': str(self.stopCueFade.isChecked()),
             'pausecuefade': str(self.pauseCueFade.isChecked()),
             'resumecuefade': str(self.resumeCueFade.isChecked()),
@@ -158,6 +163,7 @@ class ListLayoutSettings(SettingsPage):
         self.goKeyEdit.setKeySequence(
             QKeySequence(settings.get('gokey', 'Space'),
                          QKeySequence.NativeText))
+        self.disableGoKeyWhilePlaying.setChecked(settings.get('disablegokeywhileplaying') == 'True')
 
         self.stopCueFade.setChecked(settings.get('stopcuefade') == 'True')
         self.pauseCueFade.setChecked(settings.get('pausecuefade') == 'True')

--- a/lisp/layouts/list_layout/playing_list_widget.py
+++ b/lisp/layouts/list_layout/playing_list_widget.py
@@ -81,6 +81,9 @@ class RunningCuesListWidget(QListWidget):
         for item in self._running_cues.values():
             self.itemWidget(item).set_accurate_time(accurate)
 
+    def has_running_cues(self):
+        return len(self._running_cues) > 0
+    
     def _item_added(self, cue):
         widget = get_running_widget(cue, parent=self)
         widget.set_accurate_time(self.__accurate_time)


### PR DESCRIPTION
Adds a config option to allow disabling the Go hotkey in list layout mode while there are actively playing cues. 

The Go button itself will still work, as will any programmed triggers, etc. It only disables the go key combo as to prevent accidentally triggering the next cue.

The text on the config screen is still ugly, wanted to see if this would be accepted in general before I dig into that.