### PR TITLE
allow config to disable go key while playing

### DIFF
--- a/lisp/plugins/list_layout/default.json
+++ b/lisp/plugins/list_layout/default.json
@@ -9,6 +9,7 @@
     "selectionMode": false,
     "autoContinue": true,
     "goKey": "Space",
+    "goKeyDisabledWhilePlaying": false,
     "goAction": "Default",
     "goDelay": 100,
     "stopCueFade": true,

--- a/lisp/plugins/list_layout/models.py
+++ b/lisp/plugins/list_layout/models.py
@@ -93,6 +93,9 @@ class RunningCueModel(ReadOnlyProxyModel):
         super().__init__(model)
         self.__playing = []
 
+    def is_playing(self):
+        return len(self.__playing) > 0
+
     def _item_added(self, item):
         item.end.connect(self._remove)
         item.started.connect(self._add)

--- a/lisp/plugins/list_layout/playing_view.py
+++ b/lisp/plugins/list_layout/playing_view.py
@@ -84,6 +84,9 @@ class RunningCuesListWidget(QListWidget):
         for item in self._running_cues.values():
             self.itemWidget(item).set_accurate_time(accurate)
 
+    def has_running_cues(self):
+        return len(self._running_cues) > 0
+
     def _item_added(self, cue):
         widget = get_running_widget(cue, self._config, parent=self)
         widget.updateSize(self.viewport().width())

--- a/lisp/plugins/list_layout/settings.py
+++ b/lisp/plugins/list_layout/settings.py
@@ -84,6 +84,9 @@ class ListLayoutSettings(SettingsPage):
         self.goDelaySpin.setMaximum(10000)
         self.goLayout.addWidget(self.goDelaySpin, 2, 1)
 
+        self.goKeyDisabledWhilePlaying = QCheckBox(self.behaviorsGroup)
+        self.goLayout.addWidget(self.goKeyDisabledWhilePlaying)
+
         self.useFadeGroup = QGroupBox(self)
         self.useFadeGroup.setLayout(QGridLayout())
         self.layout().addWidget(self.useFadeGroup)
@@ -117,6 +120,7 @@ class ListLayoutSettings(SettingsPage):
         self.goDelayLabel.setText(
             translate("ListLayout", "GO minimum interval (ms):")
         )
+        self.goKeyDisabledWhilePlaying.setText(translate("ListLayout", "GO Key Disabled While Playing"))
 
         self.useFadeGroup.setTitle(
             translate("ListLayout", "Use fade (buttons)")
@@ -138,6 +142,7 @@ class ListLayoutSettings(SettingsPage):
         )
         self.goActionCombo.setCurrentItem(settings["goAction"])
         self.goDelaySpin.setValue(settings["goDelay"])
+        self.goKeyDisabledWhilePlaying.setChecked(settings["goKeyDisabledWhilePlaying"])
 
         self.stopCueFade.setChecked(settings["stopCueFade"])
         self.pauseCueFade.setChecked(settings["pauseCueFade"])
@@ -158,6 +163,7 @@ class ListLayoutSettings(SettingsPage):
             ),
             "goAction": self.goActionCombo.currentItem(),
             "goDelay": self.goDelaySpin.value(),
+            "goKeyDisabledWhilePlaying": self.goKeyDisabledWhilePlaying.isChecked(),
             "stopCueFade": self.stopCueFade.isChecked(),
             "pauseCueFade": self.pauseCueFade.isChecked(),
             "resumeCueFade": self.resumeCueFade.isChecked(),


### PR DESCRIPTION
Adds a config option to allow disabling the Go hotkey in list layout mode while there are actively playing cues. 

The Go button itself will still work, as will any programmed triggers, etc. It only disables the go key combo as to prevent accidentally triggering the next cue.

For some reason I cannot get the setting from the defaults to actually apply when a list layout is loaded (having to manually apply the settings via the layout menu), but this seems to be the case for all of the options at the moment