### PR TITLE
Drag'n drop files from file manager (issue #137)

### DIFF
--- a/lisp/plugins/gst_backend/gst_backend.py
+++ b/lisp/plugins/gst_backend/gst_backend.py
@@ -120,7 +120,21 @@ class GstBackend(Plugin, BaseBackend):
         if files:
             GstBackend.Config["mediaLookupDir"] = os.path.dirname(files[0])
             GstBackend.Config.write()
+        self.add_cue_from_files(files)
 
+    def add_cue_from_urls(self, urls):
+        extensions = self.supported_extensions()
+        files = []
+        for url in urls:
+            filename = url.path()
+            ext = os.path.splitext(url.fileName())[-1]
+            if ext.strip('.') not in extensions['audio'] + extensions['video']:
+                # Skip unsupported media types
+                continue
+            files.append(filename)
+        self.add_cue_from_files(files)
+
+    def add_cue_from_files(self, files):
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
 
         # Create media cues, and add them to the Application cue_model


### PR DESCRIPTION
Hi,
I was looking to use linux-show-player in our local radio and missing the ability to drop files from the file manager was a noted sore point, hence this pull request. It's made of two commits, one for the list view (this was our primary demand) and one for the card layout.
I only tested it with Nautilus but I don't think it has anything specific and it should work as is with other file managers. (also I never used PyQt before)