### PR TITLE
Implement a form of "plugin status"

### DIFF
--- a/lisp/core/plugin.py
+++ b/lisp/core/plugin.py
@@ -17,6 +17,7 @@
 
 from lisp.core.configuration import DummyConfiguration
 from lisp.plugins import PluginState
+from lisp.ui.ui_utils import translate
 
 
 # TODO: add possible additional metadata (Icon, Version, ...)
@@ -55,10 +56,28 @@ class Plugin:
 
     @classmethod
     def status_icon(cls):
-        if cls.is_disabled():
-            return 'led-off'
         if cls.State & PluginState.InError:
             return 'led-error'
+
         if cls.State & PluginState.InWarning:
+            if cls.is_disabled():
+                return 'led-pause-outline'
             return 'led-pause'
+
+        if cls.is_disabled():
+            return 'led-off'
         return 'led-running'
+
+    @classmethod
+    def status_tooltip(cls):
+        if cls.State & PluginState.InError:
+            return translate('PluginsTooltip', 'An error has occurred with this plugin. Please see logs for further information.')
+
+        if cls.State & PluginState.InWarning:
+            if cls.is_disabled():
+                return translate('PluginsTooltip', 'There is a non-critical issue with this disabled plugin. Please see logs for further information.')
+            return translate('PluginsTooltip', 'A non-critical issue is affecting this plugin. Please see logs for further information.')
+
+        if cls.is_disabled():
+            return translate('PluginsTooltip', 'Plugin disabled. Enable to use.')
+        return translate('PluginsTooltip', 'Plugin loaded and ready for use.')

--- a/lisp/core/plugin.py
+++ b/lisp/core/plugin.py
@@ -47,8 +47,8 @@ class Plugin:
         self.__class__.State &= ~PluginState.Loaded
 
     @classmethod
-    def is_disabled(cls):
-        return not cls.Config.get("_enabled_", False)
+    def is_enabled(cls):
+        return cls.Config.get("_enabled_", False)
 
     @classmethod
     def is_loaded(cls):
@@ -60,13 +60,13 @@ class Plugin:
             return 'led-error'
 
         if cls.State & PluginState.InWarning:
-            if cls.is_disabled():
-                return 'led-pause-outline'
-            return 'led-pause'
+            if cls.is_enabled():
+                return 'led-pause'
+            return 'led-pause-outline'
 
-        if cls.is_disabled():
-            return 'led-off'
-        return 'led-running'
+        if cls.is_enabled():
+            return 'led-running'
+        return 'led-off'
 
     @classmethod
     def status_tooltip(cls):
@@ -74,10 +74,10 @@ class Plugin:
             return translate('PluginsTooltip', 'An error has occurred with this plugin. Please see logs for further information.')
 
         if cls.State & PluginState.InWarning:
-            if cls.is_disabled():
-                return translate('PluginsTooltip', 'There is a non-critical issue with this disabled plugin. Please see logs for further information.')
-            return translate('PluginsTooltip', 'A non-critical issue is affecting this plugin. Please see logs for further information.')
+            if cls.is_enabled():
+                return translate('PluginsTooltip', 'A non-critical issue is affecting this plugin. Please see logs for further information.')
+            return translate('PluginsTooltip', 'There is a non-critical issue with this disabled plugin. Please see logs for further information.')
 
-        if cls.is_disabled():
-            return translate('PluginsTooltip', 'Plugin disabled. Enable to use.')
-        return translate('PluginsTooltip', 'Plugin loaded and ready for use.')
+        if cls.is_enabled():
+            return translate('PluginsTooltip', 'Plugin loaded and ready for use.')
+        return translate('PluginsTooltip', 'Plugin disabled. Enable to use.')

--- a/lisp/core/plugin.py
+++ b/lisp/core/plugin.py
@@ -41,3 +41,7 @@ class Plugin:
 
     def finalize(self):
         """Called when the application is getting closed."""
+
+    @classmethod
+    def is_disabled(cls):
+        return not cls.Config.get("_enabled_", False)

--- a/lisp/plugins/__init__.py
+++ b/lisp/plugins/__init__.py
@@ -120,7 +120,7 @@ def __load_plugins(plugins, application, optionals=True):
 
             # Try to load the plugin, if enabled
             try:
-                if plugin.Config.get("_enabled_", False):
+                if not plugin.is_disabled():
                     # Create an instance of the plugin and save it
                     LOADED[name] = plugin(application)
                     logger.info(

--- a/lisp/plugins/__init__.py
+++ b/lisp/plugins/__init__.py
@@ -140,7 +140,7 @@ def __load_plugins(plugins, application, optionals=True):
 
             # Try to load the plugin, if enabled
             try:
-                if not plugin.is_disabled():
+                if plugin.is_enabled():
                     # Create an instance of the plugin and save it
                     PLUGINS[name] = plugin(application)
                     logger.info(

--- a/lisp/plugins/__init__.py
+++ b/lisp/plugins/__init__.py
@@ -131,7 +131,12 @@ def __load_plugins(plugins, application, optionals=True):
         else:
             plugins.pop(name)
             resolved = True
-            plugin.State &= ~PluginState.DependenciesNotSatisfied
+            plugin.State &= ~(PluginState.DependenciesNotSatisfied | PluginState.OptionalDependenciesNotSatisfied)
+
+            for dep in plugin.OptDepends:
+                if dep not in PLUGINS or not PLUGINS[dep].is_loaded():
+                    plugin.State |= PluginState.OptionalDependenciesNotSatisfied
+                    break
 
             # Try to load the plugin, if enabled
             try:

--- a/lisp/ui/icons/lisp/led-error-outline.svg
+++ b/lisp/ui/icons/lisp/led-error-outline.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   style="enable-background:new"
+   id="svg24"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata30">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs28">
+    <filter
+       height="1.096"
+       y="-0.048"
+       width="1.096"
+       x="-0.048"
+       id="filter1689"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur1691"
+         stdDeviation="0.28601563" />
+    </filter>
+  </defs>
+  <radialGradient
+     spreadMethod="pad"
+     r="136.37059"
+     gradientUnits="userSpaceOnUse"
+     cy="477.58539"
+     cx="370.72598"
+     id="a">
+    <stop
+       id="stop2"
+       stop-color="#05ff05"
+       offset="0" />
+    <stop
+       id="stop4"
+       stop-opacity=".784314"
+       stop-color="#4bff4b"
+       offset=".64814812" />
+    <stop
+       id="stop6"
+       stop-opacity=".588235"
+       stop-color="#4bff4b"
+       offset=".82407403" />
+    <stop
+       id="stop8"
+       stop-opacity="0"
+       offset="1" />
+  </radialGradient>
+  <filter
+     style="color-interpolation-filters:sRGB"
+     y="0"
+     x="0"
+     width="1"
+     height="1"
+     id="b">
+    <feColorMatrix
+       id="feColorMatrix11"
+       values="0"
+       type="hueRotate" />
+    <feColorMatrix
+       id="feColorMatrix13"
+       values="1"
+       type="saturate" />
+    <feColorMatrix
+       id="feColorMatrix15"
+       values="2 -1 0 0 0 0 2 -1 0 0 -1 0 2 0 0 0 0 0 1 0"
+       type="matrix"
+       result="fbSourceGraphic" />
+    <feColorMatrix
+       id="feColorMatrix17"
+       values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+       result="fbSourceGraphicAlpha"
+       in="fbSourceGraphic" />
+    <feGaussianBlur
+       id="feGaussianBlur19"
+       stdDeviation="3"
+       in="fbSourceGraphic" />
+  </filter>
+  <path
+     id="path2980"
+     d="M 8.0000001,0.84960952 A 7.1500001,7.1500001 0 0 0 0.84960952,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,15.150391 7.1500001,7.1500001 0 0 0 15.150391,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,0.84960952 Z m 0,2.15039058 A 5,5 0 0 1 13,8.0000001 5,5 0 0 1 8.0000001,13 a 5,5 0 0 1 -5,-4.9999999 5,5 0 0 1 5,-5 z"
+     style="opacity:1;fill:#cd0f0f;fill-opacity:0.48235294;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.48235294;paint-order:normal;filter:url(#filter1689)" />
+  <circle
+     style="opacity:1;fill:none;fill-opacity:0.4825175;stroke:#cd0f0f;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="circle1518"
+     cx="8"
+     cy="8"
+     r="6.0500002" />
+</svg>

--- a/lisp/ui/icons/lisp/led-off-outline.svg
+++ b/lisp/ui/icons/lisp/led-off-outline.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   style="enable-background:new"
+   id="svg24"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata30">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs28">
+    <filter
+       height="1.096"
+       y="-0.048"
+       width="1.096"
+       x="-0.048"
+       id="filter1689"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur1691"
+         stdDeviation="0.28601563" />
+    </filter>
+  </defs>
+  <radialGradient
+     spreadMethod="pad"
+     r="136.37059"
+     gradientUnits="userSpaceOnUse"
+     cy="477.58539"
+     cx="370.72598"
+     id="a">
+    <stop
+       id="stop2"
+       stop-color="#05ff05"
+       offset="0" />
+    <stop
+       id="stop4"
+       stop-opacity=".784314"
+       stop-color="#4bff4b"
+       offset=".64814812" />
+    <stop
+       id="stop6"
+       stop-opacity=".588235"
+       stop-color="#4bff4b"
+       offset=".82407403" />
+    <stop
+       id="stop8"
+       stop-opacity="0"
+       offset="1" />
+  </radialGradient>
+  <filter
+     style="color-interpolation-filters:sRGB"
+     y="0"
+     x="0"
+     width="1"
+     height="1"
+     id="b">
+    <feColorMatrix
+       id="feColorMatrix11"
+       values="0"
+       type="hueRotate" />
+    <feColorMatrix
+       id="feColorMatrix13"
+       values="1"
+       type="saturate" />
+    <feColorMatrix
+       id="feColorMatrix15"
+       values="2 -1 0 0 0 0 2 -1 0 0 -1 0 2 0 0 0 0 0 1 0"
+       type="matrix"
+       result="fbSourceGraphic" />
+    <feColorMatrix
+       id="feColorMatrix17"
+       values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+       result="fbSourceGraphicAlpha"
+       in="fbSourceGraphic" />
+    <feGaussianBlur
+       id="feGaussianBlur19"
+       stdDeviation="3"
+       in="fbSourceGraphic" />
+  </filter>
+  <path
+     id="path2980"
+     d="M 8.0000001,0.84960952 A 7.1500001,7.1500001 0 0 0 0.84960952,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,15.150391 7.1500001,7.1500001 0 0 0 15.150391,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,0.84960952 Z m 0,2.15039058 A 5,5 0 0 1 13,8.0000001 5,5 0 0 1 8.0000001,13 a 5,5 0 0 1 -5,-4.9999999 5,5 0 0 1 5,-5 z"
+     style="opacity:1;fill:#969696;fill-opacity:0.48235294;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.48235294;paint-order:normal;filter:url(#filter1689)" />
+  <circle
+     style="opacity:1;fill:none;fill-opacity:0.4825175;stroke:#969696;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="circle1518"
+     cx="8"
+     cy="8"
+     r="6.0500002" />
+</svg>

--- a/lisp/ui/icons/lisp/led-pause-outline.svg
+++ b/lisp/ui/icons/lisp/led-pause-outline.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   style="enable-background:new"
+   id="svg24"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata30">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs28">
+    <filter
+       height="1.096"
+       y="-0.048"
+       width="1.096"
+       x="-0.048"
+       id="filter1689"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur1691"
+         stdDeviation="0.28601563" />
+    </filter>
+  </defs>
+  <radialGradient
+     spreadMethod="pad"
+     r="136.37059"
+     gradientUnits="userSpaceOnUse"
+     cy="477.58539"
+     cx="370.72598"
+     id="a">
+    <stop
+       id="stop2"
+       stop-color="#05ff05"
+       offset="0" />
+    <stop
+       id="stop4"
+       stop-opacity=".784314"
+       stop-color="#4bff4b"
+       offset=".64814812" />
+    <stop
+       id="stop6"
+       stop-opacity=".588235"
+       stop-color="#4bff4b"
+       offset=".82407403" />
+    <stop
+       id="stop8"
+       stop-opacity="0"
+       offset="1" />
+  </radialGradient>
+  <filter
+     style="color-interpolation-filters:sRGB"
+     y="0"
+     x="0"
+     width="1"
+     height="1"
+     id="b">
+    <feColorMatrix
+       id="feColorMatrix11"
+       values="0"
+       type="hueRotate" />
+    <feColorMatrix
+       id="feColorMatrix13"
+       values="1"
+       type="saturate" />
+    <feColorMatrix
+       id="feColorMatrix15"
+       values="2 -1 0 0 0 0 2 -1 0 0 -1 0 2 0 0 0 0 0 1 0"
+       type="matrix"
+       result="fbSourceGraphic" />
+    <feColorMatrix
+       id="feColorMatrix17"
+       values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+       result="fbSourceGraphicAlpha"
+       in="fbSourceGraphic" />
+    <feGaussianBlur
+       id="feGaussianBlur19"
+       stdDeviation="3"
+       in="fbSourceGraphic" />
+  </filter>
+  <path
+     id="path2980"
+     d="M 8.0000001,0.84960952 A 7.1500001,7.1500001 0 0 0 0.84960952,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,15.150391 7.1500001,7.1500001 0 0 0 15.150391,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,0.84960952 Z m 0,2.15039058 A 5,5 0 0 1 13,8.0000001 5,5 0 0 1 8.0000001,13 a 5,5 0 0 1 -5,-4.9999999 5,5 0 0 1 5,-5 z"
+     style="opacity:1;fill:#a97700;fill-opacity:0.48235294;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.48235294;paint-order:normal;filter:url(#filter1689)" />
+  <circle
+     style="opacity:1;fill:none;fill-opacity:0.4825175;stroke:#ffb505;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="circle1518"
+     cx="8"
+     cy="8"
+     r="6.0500002" />
+</svg>

--- a/lisp/ui/icons/lisp/led-running-outline.svg
+++ b/lisp/ui/icons/lisp/led-running-outline.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   style="enable-background:new"
+   id="svg24"
+   version="1.1"
+   width="16"
+   height="16">
+  <metadata
+     id="metadata30">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs28">
+    <filter
+       height="1.096"
+       y="-0.048"
+       width="1.096"
+       x="-0.048"
+       id="filter1689"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur1691"
+         stdDeviation="0.28601563" />
+    </filter>
+  </defs>
+  <radialGradient
+     spreadMethod="pad"
+     r="136.37059"
+     gradientUnits="userSpaceOnUse"
+     cy="477.58539"
+     cx="370.72598"
+     id="a">
+    <stop
+       id="stop2"
+       stop-color="#05ff05"
+       offset="0" />
+    <stop
+       id="stop4"
+       stop-opacity=".784314"
+       stop-color="#4bff4b"
+       offset=".64814812" />
+    <stop
+       id="stop6"
+       stop-opacity=".588235"
+       stop-color="#4bff4b"
+       offset=".82407403" />
+    <stop
+       id="stop8"
+       stop-opacity="0"
+       offset="1" />
+  </radialGradient>
+  <filter
+     style="color-interpolation-filters:sRGB"
+     y="0"
+     x="0"
+     width="1"
+     height="1"
+     id="b">
+    <feColorMatrix
+       id="feColorMatrix11"
+       values="0"
+       type="hueRotate" />
+    <feColorMatrix
+       id="feColorMatrix13"
+       values="1"
+       type="saturate" />
+    <feColorMatrix
+       id="feColorMatrix15"
+       values="2 -1 0 0 0 0 2 -1 0 0 -1 0 2 0 0 0 0 0 1 0"
+       type="matrix"
+       result="fbSourceGraphic" />
+    <feColorMatrix
+       id="feColorMatrix17"
+       values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+       result="fbSourceGraphicAlpha"
+       in="fbSourceGraphic" />
+    <feGaussianBlur
+       id="feGaussianBlur19"
+       stdDeviation="3"
+       in="fbSourceGraphic" />
+  </filter>
+  <path
+     id="path2980"
+     d="M 8.0000001,0.84960952 A 7.1500001,7.1500001 0 0 0 0.84960952,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,15.150391 7.1500001,7.1500001 0 0 0 15.150391,8.0000001 7.1500001,7.1500001 0 0 0 8.0000001,0.84960952 Z m 0,2.15039058 A 5,5 0 0 1 13,8.0000001 5,5 0 0 1 8.0000001,13 a 5,5 0 0 1 -5,-4.9999999 5,5 0 0 1 5,-5 z"
+     style="opacity:1;fill:#09a900;fill-opacity:0.48235294;stroke:none;stroke-width:1.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.48235294;paint-order:normal;filter:url(#filter1689)" />
+  <circle
+     style="opacity:1;fill:none;fill-opacity:0.4825175;stroke:#05ff05;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="circle1518"
+     cx="8"
+     cy="8"
+     r="6.0500002" />
+</svg>

--- a/lisp/ui/settings/app_pages/plugins.py
+++ b/lisp/ui/settings/app_pages/plugins.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2017 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -47,12 +47,7 @@ class PluginsSettings(SettingsPage):
 
         for name, plugin in plugins.PLUGINS.items():
             item = QListWidgetItem(plugin.Name)
-            if plugins.is_loaded(name):
-                item.setIcon(IconTheme.get("led-running"))
-            elif not plugin.Config["_enabled_"]:
-                item.setIcon(IconTheme.get("led-pause"))
-            else:
-                item.setIcon(IconTheme.get("led-error"))
+            item.setIcon(IconTheme.get(plugin.status_icon()))
 
             item.setData(Qt.UserRole, plugin)
 

--- a/lisp/ui/settings/app_pages/plugins.py
+++ b/lisp/ui/settings/app_pages/plugins.py
@@ -48,6 +48,7 @@ class PluginsSettings(SettingsPage):
         for name, plugin in plugins.PLUGINS.items():
             item = QListWidgetItem(plugin.Name)
             item.setIcon(IconTheme.get(plugin.status_icon()))
+            item.setToolTip(plugin.status_tooltip())
 
             item.setData(Qt.UserRole, plugin)
 


### PR DESCRIPTION
This PR adds a way of acquiring the status or state of a plugin.

It is now possible to query a plugin directly to see if it is loaded or disabled; and to request a suitable status icon and tooltip for use in GUI ([preview](https://user-images.githubusercontent.com/2053873/73013176-ba584500-3e0f-11ea-988c-d9cb32f81b1b.jpg)).

There are also a few more status icon varieties.


----

Thoughts:

* Would it be worth adding methods to the `Plugin` class that can be used to check if it is in Error or Warning?
    - If Plugin-A could optionally use Plugin-B, then Plugin-A can simply check if Plugin-B is loaded or not. The fact that Plugin-B is in error is (for now) irrelevant.
    - Whilst the only current error is that dependencies are not satisfied (and this also prevents the plugin from being loaded), it is feasible that an error could occur after load. (Thus a plugin is both Loaded and Errored, in which case Plugin-A should need to detect that so it doesn't use Plugin-B.)
    - Perhaps an `is_usable` method? (`True` when Loaded and not Errored.)

* Should the Plugin class set all status flags internally (as with this PR the `DependenciesNotSatisfied` and `OptionalDependenciesNotSatified` flags are set outside the class)?

* Would the `is_disabled` method be better as an `is_enabled` method?
