### PR TITLE
[0.5.x] Detect qt5ct and workaround it

### DIFF
--- a/lisp/main.py
+++ b/lisp/main.py
@@ -21,9 +21,9 @@ import argparse
 import logging
 import sys
 from itertools import chain
-from os import path
+from os import environ, path
 
-from PyQt5.QtCore import QTranslator, QLocale, QLibraryInfo, QProcessEnvironment
+from PyQt5.QtCore import QTranslator, QLocale, QLibraryInfo
 from PyQt5.QtGui import QFont, QIcon
 from PyQt5.QtWidgets import QApplication
 
@@ -64,10 +64,9 @@ def main():
     )
 
     # Detect qt5ct (icons do not appear when qt5ct is installed)
-    env = QProcessEnvironment.systemEnvironment()
-    if env.contains('QT_QPA_PLATFORMTHEME') and env.value('QT_QPA_PLATFORMTHEME') == 'qt5ct':
+    if 'QT_QPA_PLATFORMTHEME' in environ and environ['QT_QPA_PLATFORMTHEME'] == 'qt5ct':
         logging.warning('qt5ct detected. Linux Show Player and qt5ct are not compatible. Overriding.')
-        sys.argv += ['-platformtheme', '']
+        del environ['QT_QPA_PLATFORMTHEME']
 
     # Create the QApplication
     qt_app = QApplication(sys.argv)

--- a/lisp/main.py
+++ b/lisp/main.py
@@ -23,7 +23,7 @@ import sys
 from itertools import chain
 from os import path
 
-from PyQt5.QtCore import QTranslator, QLocale, QLibraryInfo
+from PyQt5.QtCore import QTranslator, QLocale, QLibraryInfo, QProcessEnvironment
 from PyQt5.QtGui import QFont, QIcon
 from PyQt5.QtWidgets import QApplication
 
@@ -62,6 +62,12 @@ def main():
         datefmt='%H:%M:%S',
         level=log
     )
+
+    # Detect qt5ct (icons do not appear when qt5ct is installed)
+    env = QProcessEnvironment.systemEnvironment()
+    if env.contains('QT_QPA_PLATFORMTHEME') and env.value('QT_QPA_PLATFORMTHEME') == 'qt5ct':
+        logging.warning('qt5ct detected. Linux Show Player and qt5ct are not compatible. Overriding.')
+        sys.argv += ['-platformtheme', '']
 
     # Create the QApplication
     qt_app = QApplication(sys.argv)


### PR DESCRIPTION
(Written in response to the recent various "icons not being drawn" comments.)

`qt5ct` creates (or requires the user to create) the environment argument `QT_QPA_PLATFORMTHEME` with the value `qt5ct`.

The code supplied below detects the existence of the environment argument, checks its value, and if relevant adds a (blank) argument to be passed to the invocation of `QApplication`. This appears to causes Qt to ignore the environment value and fallback on the default platform theme.

----

A fix doesn't seem to be needed for the `0.6`/`develop` branch.