### PR TITLE
Support loading plugins from a User's home directory

### DIFF
--- a/lisp/plugins/__init__.py
+++ b/lisp/plugins/__init__.py
@@ -17,7 +17,8 @@
 
 import inspect
 import logging
-from os import path
+from os import makedirs, path
+import sys
 
 from lisp import app_dirs
 from lisp.core.configuration import JSONFileConfiguration
@@ -28,6 +29,11 @@ PLUGINS = {}
 LOADED = {}
 
 FALLBACK_CONFIG_PATH = path.join(path.dirname(__file__), "default.json")
+USER_PLUGIN_PATH = path.join(app_dirs.user_data_dir, "plugins")
+
+# Make sure the path exists, and insert it into the list of paths python uses to find modules
+makedirs(USER_PLUGIN_PATH, exist_ok=True)
+sys.path.insert(1, USER_PLUGIN_PATH)
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +44,17 @@ class PluginNotLoadedError(Exception):
 
 def load_plugins(application):
     """Load and instantiate available plugins."""
-    for name, plugin in load_classes(__package__, path.dirname(__file__)):
+
+    def callback(name, plugin):
+
+        if name in PLUGINS:
+            # We don't want users to be able to override plugins that are provided with lisp
+            logger.error(
+                translate("PluginsError",
+                          'A plugin by the name of "{}" already exists.').format(name)
+            )
+            return
+
         try:
             PLUGINS[name] = plugin
 
@@ -63,6 +79,14 @@ def load_plugins(application):
             logger.exception(
                 translate("PluginsError", 'Failed to load "{}"').format(name)
             )
+
+    # Load plugins that install with lisp
+    for name, plugin in load_classes(__package__, path.dirname(__file__)):
+        callback(name, plugin)
+
+    # Load plugins that a user has installed to their profile
+    for name, plugin in load_classes("", USER_PLUGIN_PATH):
+        callback(name, plugin)
 
     __init_plugins(application)
 


### PR DESCRIPTION
#### *gitter*, December 2018:
> ##### s0600204:
> Which begs the question - how do you envision plugin installation working in the future? [...] Hypothetically, how would these custom plugins be "packaged" so that someone else can easily "install" them?
>
> ##### FrancescoCeruti:
> I've thought a bit about that, ideally you could simply have a directory in the user home (under .linux_show_player), where LiSP looks for user installed plugins. [...] They can be packaged as zip files or similar with a metadata file.

This set of changes is an attempt to permit the above.

With this PR, it is possible to place a plugin in the folder `$XDG_DATA_HOME/LinuxShowPlayer/$LiSP_Version/plugins/` (e.g. `~/.local/share/LinuxShowPlayer/0.6/plugins/`) and LiSP will load it on next program restart.

As an example, I've created a plugin over at https://github.com/s0600204/protocol_monitor. To test, you can clone the repo into `~/.local/share/LinuxShowPlayer/0.6/plugins/protocol_monitor` (such that that is the root folder of the repo) and (re)start LiSP. (Or alternatively, move one of the plugins included with LiSP out.)

It is also possible with this PR to have a plugin zipped up. Unfortunately, downloading a zip-file from GitHub and using it directly is not possible (GitHub doesn't create the subfolder within the zip-file with the correct name), however creating a zip-file manually with the layout:
```
  example.zip
     '- example_plugin/
         |- __init__.py
         |- default.json
         '- example_plugin.py
```
should work.

There is a caveat with using a zip-file: whilst python code is included automatically, other files have to be extracted programmatically before being usable. The `default.json` file is example of this, and this pull-request includes code that creates a temporary folder and extracts it automatically on plugin load (the temporary folder is removed again when LiSP closes).