### PR TITLE
Draw scale markings on level meters

### DIFF
--- a/lisp/plugins/list_layout/playing_widgets.py
+++ b/lisp/plugins/list_layout/playing_widgets.py
@@ -227,7 +227,7 @@ class RunningMediaCueWidget(RunningCueWidget):
         # Add/Remove the QDbMeter in the layout
         if visible and not self.dbmeter.isVisible():
             self.gridLayout.addWidget(self.dbmeter, 0, 2, 3, 1)
-            self.gridLayout.setColumnStretch(2, 1)
+            self.gridLayout.setColumnStretch(2, 2)
         elif not visible and self.dbmeter.isVisible():
             self.gridLayout.removeWidget(self.dbmeter)
             self.gridLayout.setColumnStretch(2, 0)

--- a/lisp/ui/widgets/dbmeter.py
+++ b/lisp/ui/widgets/dbmeter.py
@@ -63,6 +63,7 @@ class DBMeter(QWidget):
         font.setPointSize(font.pointSize() - 1)
         self.unit_font = font
         self.scale_width = 0
+        self.paint_scale_text = True
 
         self.reset()
 
@@ -118,6 +119,8 @@ class DBMeter(QWidget):
             QFontMetrics(self.unit_font).boundingRect(self.unit).width()
         )
 
+        self.paint_scale_text = self.width() > self.scale_width * 2
+
     def updatePixmap(self):
         """Prepare the colored rect to be used during paintEvent(s)"""
         w = self.width()
@@ -147,7 +150,11 @@ class DBMeter(QWidget):
         painter.setBrush(self.backgroundColor)
 
         # Calculate the meter size (per single channel)
-        meterWidth = (width - self.scale_width) / len(self.peaks)
+        if self.paint_scale_text:
+            usableWidth = (width - self.scale_width)
+        else:
+            usableWidth = width
+        meterWidth = usableWidth / len(self.peaks)
         meterRect = QRect(0, 0, meterWidth - 2, height - 1)
 
         # Draw each channel
@@ -193,6 +200,10 @@ class DBMeter(QWidget):
 
             # Move to the next meter
             meterRect.translate(meterWidth, 0)
+
+        if not self.paint_scale_text:
+            painter.end()
+            return
 
         # Write the scale marking text
         text_height = QFontMetrics(self.font()).height()

--- a/lisp/ui/widgets/dbmeter.py
+++ b/lisp/ui/widgets/dbmeter.py
@@ -18,7 +18,7 @@
 from math import ceil
 from typing import Callable
 
-from PyQt5.QtCore import QPointF, QRect, QRectF, Qt
+from PyQt5.QtCore import QPoint, QPointF, QRect, QRectF, Qt
 from PyQt5.QtGui import QLinearGradient, QColor, QPainter, QPixmap, QFontDatabase, QFontMetrics
 from PyQt5.QtWidgets import QWidget
 
@@ -89,7 +89,10 @@ class DBMeter(QWidget):
         self.peaks = peaks
         self.decayPeaks = decayPeak
 
-        self.update()
+        if self.paint_scale_text:
+            self.repaint(0, 0, self.width() - self.scale_width, self.height())
+        else:
+            self.repaint(0, 0, self.width(), self.height())
 
     def updateMarkings(self):
         self._markings = []
@@ -201,7 +204,7 @@ class DBMeter(QWidget):
             # Move to the next meter
             meterRect.translate(meterWidth, 0)
 
-        if not self.paint_scale_text:
+        if not self.paint_scale_text or not e.region().contains(QPoint(usableWidth, 0)):
             painter.end()
             return
 


### PR DESCRIPTION
The markings shown are those determined (by the code) to fit the space available without overlapping.

Examples:
<img src="https://user-images.githubusercontent.com/2053873/80761503-9bfe9580-8b32-11ea-88a2-7185a5cd3ebb.jpg" height="128px" alt="Meter Marks - Cart" title="Meter Marks - Cart"/> <img src="https://user-images.githubusercontent.com/2053873/80762962-6d35ee80-8b35-11ea-9970-295417f806b2.jpg" height="128px" alt="Meter Marks - List" title="Meter Marks - List"/> <img src="https://user-images.githubusercontent.com/2053873/80762509-986c0e00-8b34-11ea-8770-2001220ac3d2.jpg" height="128px" alt="Meter Marks - RF" title="Meter Marks - RF"/>