### PR TITLE
Correct OSC callback setup

### DIFF
--- a/lisp/plugins/controller/protocols/osc.py
+++ b/lisp/plugins/controller/protocols/osc.py
@@ -335,7 +335,7 @@ class OscSettings(SettingsPage):
             translate("ControllerOscSettings", "Waiting for messages:")
         )
 
-    def __show_message(self, path, args, types):
+    def __show_message(self, path, args, types, *_, **__):
         self.capturedMessage["path"] = path
         self.capturedMessage["types"] = types
         self.capturedMessage["args"] = args

--- a/lisp/plugins/osc/osc_server.py
+++ b/lisp/plugins/osc/osc_server.py
@@ -46,6 +46,7 @@ class OscServer:
         self.__lock = Lock()
 
         self.new_message = Signal()
+        self.new_message.connect(self.__log_message)
 
     @property
     def out_port(self):
@@ -84,7 +85,6 @@ class OscServer:
 
         try:
             self.__srv = ServerThread(self.__in_port)
-            self.__srv.add_method(None, None, self.__log_message)
             self.__srv.add_method(None, None, self.new_message.emit)
             self.__srv.start()
 


### PR DESCRIPTION
Having two `add_method()` with the same `path` and `args` arguments doesn't seem to
work - the second callback is never called.

This should resolve an issue @bgberk has been reporting on gitter.