### PR TITLE
Implement ability for set a preferred default ALSA device

### DIFF
--- a/lisp/plugins/gst_backend/config/__init__.py
+++ b/lisp/plugins/gst_backend/config/__init__.py
@@ -1,0 +1,26 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from os.path import dirname
+
+from lisp.core.loading import load_classes
+
+def load():
+    for name, page in load_classes(
+        __package__, dirname(__file__), suf=("Config",)
+    ):
+        yield name, page

--- a/lisp/plugins/gst_backend/config/alsa_sink.py
+++ b/lisp/plugins/gst_backend/config/alsa_sink.py
@@ -1,0 +1,38 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtCore import QT_TRANSLATE_NOOP
+
+from lisp.plugins.gst_backend.elements.alsa_sink import AlsaSink
+from lisp.plugins.gst_backend.settings.alsa_sink import AlsaSinkSettings
+
+
+class AlsaSinkConfig(AlsaSinkSettings):
+    Name = QT_TRANSLATE_NOOP("SettingsPageName", "ALSA Default Device")
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def loadSettings(self, settings):
+        device = settings.get("alsa_device", AlsaSink.FALLBACK_DEFAULT_DEVICE)
+
+        self.deviceComboBox.setCurrentText(
+            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEFAULT_DEVICE, ""))
+        )
+
+    def getSettings(self):
+        return {"alsa_device": self.deviceComboBox.currentData()}

--- a/lisp/plugins/gst_backend/config/alsa_sink.py
+++ b/lisp/plugins/gst_backend/config/alsa_sink.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2021 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,10 +28,10 @@ class AlsaSinkConfig(AlsaSinkSettings):
         super().__init__(**kwargs)
 
     def loadSettings(self, settings):
-        device = settings.get("alsa_device", AlsaSink.FALLBACK_DEFAULT_DEVICE)
+        device = settings.get("alsa_device", AlsaSink.FALLBACK_DEVICE)
 
         self.deviceComboBox.setCurrentText(
-            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEFAULT_DEVICE, ""))
+            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEVICE, ""))
         )
 
     def getSettings(self):

--- a/lisp/plugins/gst_backend/elements/alsa_sink.py
+++ b/lisp/plugins/gst_backend/elements/alsa_sink.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2016 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 from PyQt5.QtCore import QT_TRANSLATE_NOOP
 
 from lisp.backend.media_element import ElementType, MediaType
+from lisp.plugins import get_plugin
 from lisp.plugins.gst_backend.gi_repository import Gst
 from lisp.plugins.gst_backend.gst_element import GstMediaElement, GstProperty
 
@@ -27,6 +28,7 @@ class AlsaSink(GstMediaElement):
     MediaType = MediaType.Audio
     Name = QT_TRANSLATE_NOOP("MediaElementName", "ALSA Out")
 
+    FALLBACK_DEFAULT_DEVICE = "default"
     device = GstProperty("alsa_sink", "device", default="")
 
     def __init__(self, pipeline):
@@ -34,6 +36,10 @@ class AlsaSink(GstMediaElement):
 
         self.audio_resample = Gst.ElementFactory.make("audioresample", None)
         self.alsa_sink = Gst.ElementFactory.make("alsasink", "sink")
+        self.alsa_sink.set_property(
+            "device",
+            get_plugin('GstBackend').Config.get('alsa_device', self.FALLBACK_DEFAULT_DEVICE)
+        )
 
         self.pipeline.add(self.audio_resample)
         self.pipeline.add(self.alsa_sink)

--- a/lisp/plugins/gst_backend/elements/alsa_sink.py
+++ b/lisp/plugins/gst_backend/elements/alsa_sink.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2021 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ class AlsaSink(GstMediaElement):
     MediaType = MediaType.Audio
     Name = QT_TRANSLATE_NOOP("MediaElementName", "ALSA Out")
 
-    FALLBACK_DEFAULT_DEVICE = "default"
+    FALLBACK_DEVICE = "default"
     device = GstProperty("alsa_sink", "device", default="")
 
     def __init__(self, pipeline):
@@ -38,7 +38,7 @@ class AlsaSink(GstMediaElement):
         self.alsa_sink = Gst.ElementFactory.make("alsasink", "sink")
         self.alsa_sink.set_property(
             "device",
-            get_plugin('GstBackend').Config.get('alsa_device', self.FALLBACK_DEFAULT_DEVICE)
+            get_plugin('GstBackend').Config.get('alsa_device', self.FALLBACK_DEVICE)
         )
 
         self.pipeline.add(self.audio_resample)

--- a/lisp/plugins/gst_backend/elements/alsa_sink.py
+++ b/lisp/plugins/gst_backend/elements/alsa_sink.py
@@ -18,7 +18,7 @@
 from PyQt5.QtCore import QT_TRANSLATE_NOOP
 
 from lisp.backend.media_element import ElementType, MediaType
-from lisp.plugins import get_plugin
+from lisp.plugins.gst_backend import GstBackend
 from lisp.plugins.gst_backend.gi_repository import Gst
 from lisp.plugins.gst_backend.gst_element import GstMediaElement, GstProperty
 
@@ -36,10 +36,7 @@ class AlsaSink(GstMediaElement):
 
         self.audio_resample = Gst.ElementFactory.make("audioresample", None)
         self.alsa_sink = Gst.ElementFactory.make("alsasink", "sink")
-        self.alsa_sink.set_property(
-            "device",
-            get_plugin('GstBackend').Config.get('alsa_device', self.FALLBACK_DEVICE)
-        )
+        self.device = GstBackend.Config.get("alsa_device", self.FALLBACK_DEVICE)
 
         self.pipeline.add(self.audio_resample)
         self.pipeline.add(self.alsa_sink)

--- a/lisp/plugins/gst_backend/gst_backend.py
+++ b/lisp/plugins/gst_backend/gst_backend.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ from lisp.core.decorators import memoize
 from lisp.core.plugin import Plugin
 from lisp.cues.cue_factory import CueFactory
 from lisp.cues.media_cue import MediaCue
-from lisp.plugins.gst_backend import elements, settings
+from lisp.plugins.gst_backend import config, elements, settings
 from lisp.plugins.gst_backend.gi_repository import Gst
 from lisp.plugins.gst_backend.gst_media_cue import (
     GstCueFactory,
@@ -65,6 +65,11 @@ class GstBackend(Plugin, BaseBackend):
         AppConfigurationDialog.registerSettingsPage(
             "plugins.gst", GstSettings, GstBackend.Config
         )
+        # Register elements' application-level config
+        for name, page in config.load():
+            AppConfigurationDialog.registerSettingsPage(
+                f"plugins.gst.{name}", page, GstBackend.Config
+            )
         # Add MediaCue settings widget to the CueLayout
         CueSettingsRegistry().add(GstMediaSettings, MediaCue)
 

--- a/lisp/plugins/gst_backend/settings/alsa_sink.py
+++ b/lisp/plugins/gst_backend/settings/alsa_sink.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,6 +24,7 @@ from PyQt5.QtWidgets import (
 )
 from pyalsa import alsacard
 
+from lisp.plugins import get_plugin
 from lisp.plugins.gst_backend.elements.alsa_sink import AlsaSink
 from lisp.ui.settings.pages import SettingsPage
 from lisp.ui.ui_utils import translate
@@ -49,10 +50,6 @@ class AlsaSinkSettings(SettingsPage):
         self.deviceComboBox = QComboBox(self.deviceGroup)
         for name, description in self.devices.items():
             self.deviceComboBox.addItem(description, name)
-            if name == "default":
-                self.deviceComboBox.setCurrentIndex(
-                    self.deviceComboBox.count() - 1
-                )
 
         self.deviceGroup.layout().addWidget(self.deviceComboBox)
 
@@ -76,10 +73,12 @@ class AlsaSinkSettings(SettingsPage):
         self.setGroupEnabled(self.deviceGroup, enabled)
 
     def loadSettings(self, settings):
-        device = settings.get("device", "default")
+        device = settings.get("device", "")
+        if not device:
+            device = get_plugin('GstBackend').Config.get('alsa_device', AlsaSink.FALLBACK_DEFAULT_DEVICE)
 
         self.deviceComboBox.setCurrentText(
-            self.devices.get(device, self.devices.get("default", ""))
+            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEFAULT_DEVICE, ""))
         )
 
     def getSettings(self):

--- a/lisp/plugins/gst_backend/settings/alsa_sink.py
+++ b/lisp/plugins/gst_backend/settings/alsa_sink.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2020 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2021 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -75,10 +75,10 @@ class AlsaSinkSettings(SettingsPage):
     def loadSettings(self, settings):
         device = settings.get("device", "")
         if not device:
-            device = get_plugin('GstBackend').Config.get('alsa_device', AlsaSink.FALLBACK_DEFAULT_DEVICE)
+            device = get_plugin('GstBackend').Config.get('alsa_device', AlsaSink.FALLBACK_DEVICE)
 
         self.deviceComboBox.setCurrentText(
-            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEFAULT_DEVICE, ""))
+            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEVICE, ""))
         )
 
     def getSettings(self):

--- a/lisp/plugins/gst_backend/settings/alsa_sink.py
+++ b/lisp/plugins/gst_backend/settings/alsa_sink.py
@@ -24,7 +24,7 @@ from PyQt5.QtWidgets import (
 )
 from pyalsa import alsacard
 
-from lisp.plugins import get_plugin
+from lisp.plugins.gst_backend import GstBackend
 from lisp.plugins.gst_backend.elements.alsa_sink import AlsaSink
 from lisp.ui.settings.pages import SettingsPage
 from lisp.ui.ui_utils import translate
@@ -73,12 +73,13 @@ class AlsaSinkSettings(SettingsPage):
         self.setGroupEnabled(self.deviceGroup, enabled)
 
     def loadSettings(self, settings):
-        device = settings.get("device", "")
-        if not device:
-            device = get_plugin('GstBackend').Config.get('alsa_device', AlsaSink.FALLBACK_DEVICE)
+        device = settings.get(
+            "device",
+            GstBackend.Config.get("alsa_device", AlsaSink.FALLBACK_DEVICE)
+        )
 
         self.deviceComboBox.setCurrentText(
-            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEVICE, ""))
+            self.devices.get(device, self.devices.get(AlsaSink.FALLBACK_DEVICE))
         )
 
     def getSettings(self):


### PR DESCRIPTION
The chosen ALSA device will be used by new (Gst)Media Cues, instead of using the system's default device.

Previously if a user wished to use - for example - a USB soundcard, then the user would have to manually set that in every cue. Now the user may set it once, globally, and all (Gst)Media cues created afterwards will use that device.

----

The new setting may be found/configured under File > Preferences; Plugins > GStreamer > ALSA Default Device