### PR TITLE
Don't use waveform slider when playing Media cues with "Preset" source

### DIFF
--- a/lisp/plugins/list_layout/playing_widgets.py
+++ b/lisp/plugins/list_layout/playing_widgets.py
@@ -179,7 +179,7 @@ class RunningMediaCueWidget(RunningCueWidget):
         super().__init__(cue, config, **kwargs)
         self._dbmeter_element = None
 
-        if config.get("show.waveformSlider", False) and cue.media.input_uri():
+        if config.get("show.waveformSlider", False) and cue.media.input_uri() is not None:
             self.waveform = get_backend().media_waveform(cue.media)
             self.seekSlider = WaveformSlider(
                 self.waveform, parent=self.gridLayoutWidget

--- a/lisp/plugins/list_layout/playing_widgets.py
+++ b/lisp/plugins/list_layout/playing_widgets.py
@@ -179,7 +179,7 @@ class RunningMediaCueWidget(RunningCueWidget):
         super().__init__(cue, config, **kwargs)
         self._dbmeter_element = None
 
-        if config.get("show.waveformSlider", False):
+        if config.get("show.waveformSlider", False) and cue.media.input_uri():
             self.waveform = get_backend().media_waveform(cue.media)
             self.seekSlider = WaveformSlider(
                 self.waveform, parent=self.gridLayoutWidget


### PR DESCRIPTION
Currently when a `GstMediaCue` added to a List Layout with the input of the cue's pipeline set to "Preset Input" is played, an error is emitted and the cue doesn't appear in the "Playing Cues" section. (A further error is emitted when the cue ends or is stopped.)

The initial error is emitted because the waveform code attempts to generate a waveform from the cue's media file, but the Preset Input is not sourced from one.

This PR checks that the cue has a file URI, and if not fallbacks to the other slider representation.