### PR TITLE
Edit columns 

### DIFF
--- a/lisp/plugins/list_layout/list_view.py
+++ b/lisp/plugins/list_layout/list_view.py
@@ -44,12 +44,12 @@ from lisp.ui.ui_utils import translate, css_to_dict, dict_to_css
 
 
 class ListColumn:
-    def __init__(self, name, widget, resize=None, width=None, visible=True):
+    def __init__(self, name, widget, resize=None, width=None, displayName=True):
         self.baseName = name
         self.widget = widget
         self.resize = resize
         self.width = width
-        self.visible = visible
+        self.displayName = displayName
         self.action = None
 
     @property
@@ -73,7 +73,7 @@ class CueListView(QTreeWidget):
     # TODO: add ability to show/hide
     # TODO: implement columns (cue-type / target / etc..)
     COLUMNS = [
-        ListColumn("", CueStatusIcons, QHeaderView.Fixed, width=45),
+        ListColumn(QT_TRANSLATE_NOOP("ListLayoutHeader", "Cue Status"), CueStatusIcons, QHeaderView.Fixed, width=45, displayName=False),
         ListColumn("#", IndexWidget, QHeaderView.ResizeToContents),
         ListColumn(
             QT_TRANSLATE_NOOP("ListLayoutHeader", "Cue"),
@@ -89,7 +89,7 @@ class CueListView(QTreeWidget):
         ListColumn(
             QT_TRANSLATE_NOOP("ListLayoutHeader", "Post wait"), PostWaitWidget
         ),
-        ListColumn("", NextActionIcon, QHeaderView.Fixed, width=18),
+        ListColumn(QT_TRANSLATE_NOOP("ListLayoutHeader", "Next Action"), NextActionIcon, QHeaderView.Fixed, width=18, displayName=False),
     ]
 
     ITEM_DEFAULT_BG = QBrush(Qt.transparent)
@@ -116,7 +116,7 @@ class CueListView(QTreeWidget):
         self.__showMenu = self.__columnMenu.addMenu(QT_TRANSLATE_NOOP("ListLayoutHeaderMenu","Show"))
 
         # Setup the columns headers
-        self.setHeaderLabels((c.name for c in CueListView.COLUMNS))
+        self.setHeaderLabels((c.name if c.displayName else "" for c in CueListView.COLUMNS))
         for i, column in enumerate(CueListView.COLUMNS):
             if column.resize is not None:
                 self.header().setSectionResizeMode(i, column.resize)

--- a/lisp/plugins/list_layout/list_view.py
+++ b/lisp/plugins/list_layout/list_view.py
@@ -110,6 +110,7 @@ class CueListView(QTreeWidget):
         self._model.item_removed.connect(self.__cueRemoved)
         self._model.model_reset.connect(self.__modelReset)
 
+        # Create context menu for column headers
         self.__columnMenu = QMenu()
         self.__hideMenu = self.__columnMenu.addAction(QT_TRANSLATE_NOOP("ListLayoutHeaderMenu", "Hide"))
         self.__showMenu = self.__columnMenu.addMenu(QT_TRANSLATE_NOOP("ListLayoutHeaderMenu","Show"))
@@ -121,20 +122,18 @@ class CueListView(QTreeWidget):
                 self.header().setSectionResizeMode(i, column.resize)
             if column.width is not None:
                 self.setColumnWidth(i, column.width)
-            # Create popup menu
+            # Create context menu to show the column
             column.action = self.__showMenu.addAction(column.name)
             column.action.triggered.connect(
                 lambda chk, item=i: self.showColumn(item))
 
 
-        self.header().setDragEnabled(True)
+        self.header().setDragEnabled(True) 
         self.header().setStretchLastSection(False)
         
         # Connect local context menu for headers
         self.header().setContextMenuPolicy(Qt.CustomContextMenu)
         self.header().customContextMenuRequested.connect(self.__openHeaderMenu)
-
-
 
         self.setDragDropMode(self.InternalMove)
 
@@ -341,9 +340,11 @@ class CueListView(QTreeWidget):
             self.__scrollRangeGuard = False
 
     def __openHeaderMenu(self, position):
+        # Prepare and open context menu 
         index = self.indexAt(position)
         showShowMenu = False
         for i, column in enumerate(CueListView.COLUMNS):
+            # show column name in menu if column is hidden
             column.action.setVisible(self.isColumnHidden(i))
             showShowMenu |= self.isColumnHidden(i)
         self.__showMenu.menuAction().setVisible(showShowMenu)

--- a/lisp/plugins/list_layout/list_view.py
+++ b/lisp/plugins/list_layout/list_view.py
@@ -111,8 +111,8 @@ class CueListView(QTreeWidget):
         self._model.model_reset.connect(self.__modelReset)
 
         self.__columnMenu = QMenu()
-        self.__hideMenu = self.__columnMenu.addAction("Hide")
-        self.__showMenu = self.__columnMenu.addMenu("Show")
+        self.__hideMenu = self.__columnMenu.addAction(QT_TRANSLATE_NOOP("ListLayoutHeaderMenu", "Hide"))
+        self.__showMenu = self.__columnMenu.addMenu(QT_TRANSLATE_NOOP("ListLayoutHeaderMenu","Show"))
 
         # Setup the columns headers
         self.setHeaderLabels((c.name for c in CueListView.COLUMNS))


### PR DESCRIPTION
Proposed change for #69 : 
- user can drag columns to change their order. 
- context menu on header to allow each column to be hidden
- when columns are hidden, the context menu then provides list of headers to be shown.

As my first contribution, please let me know how it can be improved.