### PR TITLE
Restore background to `RunningCueWidget` instances

### DIFF
--- a/lisp/ui/themes/dark/theme.qss
+++ b/lisp/ui/themes/dark/theme.qss
@@ -717,6 +717,10 @@ CueListView:focus {
     border: 1px solid palette(light);
 }
 
+RunningCueWidget>QWidget {
+    background-color: palette(mid);
+}
+
 #ListTimeWidget {
     height: 25px;
     border-radius: 0px;


### PR DESCRIPTION
Recent commit 6fa0bfda0453d tweaked the dark-theme palette. This resulted in the List Layout's `RunningCueWidget`s to change appearance as depicted below (left: before; right: after):

![Before and After](https://user-images.githubusercontent.com/2053873/140618272-d47a6926-ce70-43cb-b7f8-a7e62d9aaa28.png)

(Seems to be a side-effect of removing the `background-color` rule from the `QWidget` ruleset within the stylesheet.)

I'm guessing that this change to the background of the `RunningCueWidget` wasn't intended, so this PR restores it:

![Result of PR Changes](https://user-images.githubusercontent.com/2053873/140618327-f7f73ca6-31b9-41e2-a3b1-e88094b10fd3.png)

You might notice that the new background is `palette(mid)` instead of `palette(window)` (the latter would be closer to the appearance pre- 6fa0bfda0453d). Feel free to change that if you prefer.
