### PR TITLE
Update IndexAction cue's combobox of actions

### DIFF
--- a/lisp/modules/action_cues/index_action_cue.py
+++ b/lisp/modules/action_cues/index_action_cue.py
@@ -124,6 +124,7 @@ class IndexActionCueSettings(SettingsPage):
 
         self.relativeCheck.setChecked(settings.get('relative', True))
         self.targetIndexSpin.setValue(settings.get('target_index', 0))
+        self._update_action_combo()
         self.actionCombo.setCurrentText(
             translate('CueAction', settings.get('action', '')))
 
@@ -142,8 +143,8 @@ class IndexActionCueSettings(SettingsPage):
         if target_class is not self._target_class:
             self._target_class = target_class
 
-            self.actionGroup.layout().removeWidget(self.actionCombo)
             self.actionCombo.deleteLater()
+            self.actionGroup.layout().removeWidget(self.actionCombo)
 
             self.actionCombo = CueActionComboBox(
                 self._target_class,
@@ -162,6 +163,7 @@ class IndexActionCueSettings(SettingsPage):
                                               max_index - self._cue_index)
             else:
                 self.targetIndexSpin.setRange(-max_index, max_index)
+        self._update_action_combo()
 
 
 CueSettingsRegistry().add_item(IndexActionCueSettings, IndexActionCue)


### PR DESCRIPTION
With this PR the combobox now gets updated under the following circumstances:

* When the user checks/unchecks the "Relative Index" box
* When the user reopens the cue settings dialog (after saving the cue previously, or after loading an existing show file)

Fixes #227

(This is already fixed within LiSP version `0.6`, and this PR is loosely based on the code used there.)