### PR TITLE
fix #230 Remove search on keypress on list layout

### DIFF
--- a/lisp/layouts/list_layout/cue_list_view.py
+++ b/lisp/layouts/list_layout/cue_list_view.py
@@ -111,6 +111,10 @@ class CueListView(QTreeWidget):
         else:
             super().contextMenuEvent(event)
 
+    def keyboardSearch(self, search):
+        # disable scroll to letter match
+        pass
+
     def keyPressEvent(self, event):
         self.key_event.emit(event)
 


### PR DESCRIPTION
fix #230 
It interfere with keyboard shortcut. When a shortkey is pressed the next cue that begin with the typed letter is selected.