### PR TITLE
Update window title on file creation and load

### DIFF
--- a/lisp/ui/mainwindow.py
+++ b/lisp/ui/mainwindow.py
@@ -330,6 +330,7 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
     def __sessionCreated(self):
         self._app.session.layout.view.show()
         self.centralWidget().layout().addWidget(self._app.session.layout.view)
+        self.updateWindowTitle()
 
     def __simpleCueInsert(self, cueClass):
         try:
@@ -388,6 +389,8 @@ class MainWindow(QMainWindow, metaclass=QSingleton):
 
         if path is not None:
             self.open_session.emit(path)
+
+        self.updateWindowTitle()
 
     def __newSession(self):
         if self.__checkSessionSaved():


### PR DESCRIPTION
Previously the window title was only updated when an open file was saved, a cue was edited, or an undo/redo occurred.

This had interesting side effects, such as when one showfile was saved and the user then opens a second: LiSP's titlebar still showed the name of the saved file and not that of the just-loaded file.

Related to #241