### PR TITLE
Implement a Loop-Release CueAction

### DIFF
--- a/lisp/cues/cue.py
+++ b/lisp/cues/cue.py
@@ -502,6 +502,10 @@ class Cue(HasProperties):
         :type fade: bool
         """
 
+    def loop_release(self):
+        """Release any remaining cue loops."""
+        pass
+
     def fadein(self, duration, fade_type):
         """Fade-in the cue.
 

--- a/lisp/cues/cue.py
+++ b/lisp/cues/cue.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2022 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -60,6 +60,7 @@ class CueAction(EqEnum):
     Pause = "Pause"
     Stop = "Stop"
     DoNothing = "DoNothing"
+    LoopRelease = "LoopRelease"
 
 
 class CueNextAction(EqEnum):
@@ -238,6 +239,8 @@ class Cue(HasProperties):
                         self._default_fade_duration(),
                         self._default_fade_type(FadeInType, FadeInType.Linear),
                     )
+            elif action == CueAction.LoopRelease:
+                self.loop_release()
 
     def _interrupt_fade_duration(self):
         return self.app.conf.get("cue.interruptFade", 0)

--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,6 +46,7 @@ class MediaCue(Cue):
         CueAction.FadeIn,
         CueAction.Interrupt,
         CueAction.FadeOutInterrupt,
+        CueAction.LoopRelease,
     )
 
     def __init__(self, app, media, id=None):
@@ -240,3 +241,6 @@ class MediaCue(Cue):
                 self.__volume.volume,
                 FadeInType[self.fadein_type],
             )
+
+    def loop_release(self):
+        self.media.loop_release()

--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -161,6 +161,9 @@ class MediaCue(Cue):
 
         self._st_lock.release()
 
+    def loop_release(self):
+        self.media.loop_release()
+
     @async_function
     def fadeout(self, duration, fade_type):
         if not self._st_lock.acquire(timeout=0.1):
@@ -241,6 +244,3 @@ class MediaCue(Cue):
                 self.__volume.volume,
                 FadeInType[self.fadein_type],
             )
-
-    def loop_release(self):
-        self.media.loop_release()

--- a/lisp/plugins/gst_backend/gst_media.py
+++ b/lisp/plugins/gst_backend/gst_media.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -299,3 +299,6 @@ class GstMedia(Media):
 
     def __duration_changed(self, duration):
         self.duration = duration
+
+    def loop_release(self):
+        self.__loop = 0

--- a/lisp/plugins/gst_backend/gst_media.py
+++ b/lisp/plugins/gst_backend/gst_media.py
@@ -139,6 +139,10 @@ class GstMedia(Media):
         if self.__seek(position):
             self.sought.emit(self, position)
 
+    def loop_release(self):
+        # if self.state == MediaState.Playing or self.state == MediaState.Paused:
+        self.__loop = 0
+
     def element(self, class_name):
         return getattr(self.elements, class_name, None)
 
@@ -299,6 +303,3 @@ class GstMedia(Media):
 
     def __duration_changed(self, duration):
         self.duration = duration
-
-    def loop_release(self):
-        self.__loop = 0

--- a/lisp/ui/settings/cue_pages/cue_general.py
+++ b/lisp/ui/settings/cue_pages/cue_general.py
@@ -86,6 +86,7 @@ class CueBehavioursPage(CueSettingsPage):
                 CueAction.Pause,
                 CueAction.FadeOutStop,
                 CueAction.FadeOutPause,
+                CueAction.LoopRelease,
             }
             .intersection(self.cueType.CueActions)
             .union({CueAction.DoNothing}),

--- a/lisp/ui/widgets/cue_actions.py
+++ b/lisp/ui/widgets/cue_actions.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2016 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,6 +35,7 @@ CueActionsStrings = {
     CueAction.Pause: QT_TRANSLATE_NOOP("CueAction", "Pause"),
     CueAction.Stop: QT_TRANSLATE_NOOP("CueAction", "Stop"),
     CueAction.DoNothing: QT_TRANSLATE_NOOP("CueAction", "Do Nothing"),
+    CueAction.LoopRelease: QT_TRANSLATE_NOOP("CueAction", "Release from Loop"),
 }
 
 


### PR DESCRIPTION
This PR adds a new "Loop Release" action to Media Cues.

When triggered on a cue that is looping, it causes the current loop to finish before stopping the cue; in comparison to the "Stop" action which stops the cue straight away (with or without a fade).

I personally use it on shows for things such as phone ringing sound effects (which sound odd if stopped abruptly); whilst a recent user on the gitter chat mentioned that this sort of functionality might be useful for "vamping": where a short stretch of music is looped for a period of time that varies between performances (for instance: underscoring the dialogue between verses in a song).
