### PR TITLE
Support more than one MIDI In/Out

### DIFF
--- a/lisp/core/signal.py
+++ b/lisp/core/signal.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2016 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -216,6 +216,9 @@ class Signal:
                     slot.call(*args, **kwargs)
                 except Exception:
                     traceback.print_exc()
+
+    def is_connected_to(self, slot_callable):
+        return slot_id(slot_callable) in self.__slots
 
     def __remove_slot(self, id_):
         with self.__lock:

--- a/lisp/plugins/midi/default.json
+++ b/lisp/plugins/midi/default.json
@@ -2,7 +2,7 @@
   "_version_": "2.1",
   "_enabled_": true,
   "backend": "mido.backends.rtmidi",
-  "inputDevice": "",
-  "outputDevice": "",
+  "inputDevices": {},
+  "outputDevices": {},
   "connectByNameMatch": true
 }

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -25,7 +25,7 @@ from lisp.core.signal import Connection, Signal
 from lisp.plugins.midi.midi_cue import MidiCue
 from lisp.plugins.midi.midi_io import MIDIOutput, MIDIInput, MIDIBase
 from lisp.plugins.midi.midi_settings import MIDISettings
-from lisp.plugins.midi.midi_utils import midi_output_names, midi_input_names, PortStatus
+from lisp.plugins.midi.midi_utils import midi_output_names, midi_input_names, PortNameMatch, PortStatus
 from lisp.plugins.midi.port_monitor import ALSAPortMonitor
 from lisp.ui.settings.app_configuration import AppConfigurationDialog
 from lisp.ui.ui_utils import translate
@@ -122,6 +122,16 @@ class Midi(Plugin):
     def input_name(self, patch_id="in#1"):
         return self.__inputs[patch_id].port_name()
 
+    def input_name_match(self, patch_id, candidate_name):
+        if patch_id not in self.__inputs:
+            return PortNameMatch.NoMatch
+        port_name = self.__inputs[patch_id].port_name()
+        if candidate_name == port_name:
+            return PortNameMatch.ExactMatch
+        if self.Config['connectByNameMatch'] and self._port_search_match(candidate_name, [port_name]):
+            return PortNameMatch.FuzzyMatch
+        return PortNameMatch.NoMatch
+
     def input_patches(self):
         patches = Midi.Config.get("inputDevices", None)
         return patches if patches else { "in#1": Midi.Config.get("inputDevice", self.__default_input) }
@@ -133,6 +143,16 @@ class Midi(Plugin):
 
     def output_name(self, patch_id="out#1"):
         return self.__outputs[patch_id].port_name()
+
+    def output_name_match(self, patch_id, candidate_name):
+        if patch_id not in self.__outputs:
+            return PortNameMatch.NoMatch
+        port_name = self.__outputs[patch_id].port_name()
+        if candidate_name == port_name:
+            return PortNameMatch.ExactMatch
+        if self.Config['connectByNameMatch'] and self._port_search_match(candidate_name, [port_name]):
+            return PortNameMatch.FuzzyMatch
+        return PortNameMatch.NoMatch
 
     def output_patches(self):
         patches = Midi.Config.get("outputDevices", None)

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2021 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -64,15 +64,17 @@ class Midi(Plugin):
         self.__default_input = avail_inputs[0] if avail_inputs else ""
         self.__default_output = avail_outputs[0] if avail_outputs else ""
 
-        # Create input handler and connect
-        current_input = self.input_name()
-        self.__input = MIDIInput(self.backend, current_input)
-        self._reconnect(self.__input, current_input, avail_inputs)
+        # Create input handlers and connect
+        self.__inputs = []
+        for name in self.input_names():
+            self.__inputs.append(MIDIInput(self.backend, name))
+            self._reconnect(self.__inputs[-1], name, avail_inputs)
 
-        # Create output handler and connect
-        current_output = self.output_name()
-        self.__output = MIDIOutput(self.backend, current_output)
-        self._reconnect(self.__output, current_output, avail_outputs)
+        # Create output handlers and connect
+        self.__outputs = []
+        for name in self.output_names():
+            self.__outputs.append(MIDIOutput(self.backend, name))
+            self._reconnect(self.__outputs[-1], name, avail_outputs)
 
         # Monitor ports, for auto-reconnection.
         # Since current midi backends are not reliable on
@@ -91,45 +93,57 @@ class Midi(Plugin):
 
     @property
     def input(self):
-        return self.__input
+        return self.__inputs[0]
 
     @property
     def output(self):
-        return self.__output
+        return self.__outputs[0]
 
     def input_name(self):
-        return Midi.Config["inputDevice"] or self.__default_input
+        return self.input_names()[0]
+
+    def input_names(self):
+        names = Midi.Config.get("inputDevices", None)
+        return names if names else [Midi.Config["inputDevice"] or self.__default_input]
 
     def output_name(self):
-        return Midi.Config["outputDevice"] or self.__default_output
+        return self.output_names()[0]
+
+    def output_names(self):
+        names = Midi.Config.get("outputDevices", None)
+        return names if names else [Midi.Config["outputDevice"] or self.__default_output]
 
     def _on_port_removed(self):
-        if self.__input.is_open():
-            if self.input_name() not in midi_input_names():
+        avail_names = self.backend.get_input_names()
+        for port in self.__inputs:
+            if port.is_open() and port.port_name() not in avail_names:
                 logger.info(
                     translate(
                         "MIDIInfo", "MIDI port disconnected: '{}'"
-                    ).format(self.__input.port_name())
+                    ).format(port.port_name())
                 )
-                self.__input.close()
+                port.close()
 
-        if self.__output.is_open():
-            if self.output_name() not in midi_output_names():
+        avail_names = self.backend.get_output_names()
+        for port in self.__outputs:
+            if port.is_open() and port.port_name() not in avail_names:
                 logger.info(
                     translate(
                         "MIDIInfo", "MIDI port disconnected: '{}'"
-                    ).format(self.__output.port_name())
+                    ).format(port.port_name())
                 )
-                self.__input.close()
+                port.close()
 
     def _on_port_added(self):
-        if not self.__input.is_open():
-            self._reconnect(self.__input, self.input_name(), midi_input_names())
+        avail_names = self.backend.get_input_names()
+        for port in self.__inputs:
+            if not port.is_open() and port.port_name() in avail_names:
+                self._reconnect(port, port.port_name(), avail_names)
 
-        if not self.__output.is_open():
-            self._reconnect(
-                self.__output, self.output_name(), midi_output_names()
-            )
+        avail_names = self.backend.get_output_names()
+        for port in self.__outputs:
+            if not port.is_open() and port.port_name() in avail_names:
+                self._reconnect(port, port.port_name(), avail_names)
 
     def _reconnect(self, midi: MIDIBase, current: str, available: list):
         if current in available:
@@ -159,9 +173,9 @@ class Midi(Plugin):
 
     def __config_change(self, key, _):
         if key == "inputDevice":
-            self.__input.change_port(self.input_name())
+            self.__inputs[0].change_port(self.input_name())
         elif key == "outputDevice":
-            self.__output.change_port(self.output_name())
+            self.__outputs[0].change_port(self.output_name())
 
     def __config_update(self, diff):
         if "inputDevice" in diff:

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -92,11 +92,11 @@ class Midi(Plugin):
 
     @property
     def input(self):
-        return self.__inputs["in#1"]
+        return self.__inputs[f"{PortDirection.Input.value}#1"]
 
     @property
     def output(self):
-        return self.__outputs["out#1"]
+        return self.__outputs[f"{PortDirection.Output.value}#1"]
 
     def add_exclusive_callback(self, patch_id, callback):
         if patch_id not in self.__inputs:
@@ -116,7 +116,7 @@ class Midi(Plugin):
             handler.exclusive_mode = False
             handler.received_exclusive.disconnect(callback)
 
-    def input_name(self, patch_id="in#1"):
+    def input_name(self, patch_id=f"{PortDirection.Input.value}#1"):
         return self.__inputs[patch_id].port_name()
 
     def input_name_match(self, patch_id, candidate_name):
@@ -131,14 +131,14 @@ class Midi(Plugin):
 
     def input_patches(self):
         patches = Midi.Config.get("inputDevices", None)
-        return patches if patches else { "in#1": Midi.Config.get("inputDevice", self.__default_input) }
+        return patches if patches else { f"{PortDirection.Input.value}#1": Midi.Config.get("inputDevice", self.__default_input) }
 
     def input_status(self, patch_id):
         if patch_id not in self.__inputs:
             return PortStatus.DoesNotExist
         return PortStatus.Open if self.__inputs[patch_id].is_open() else PortStatus.Closed
 
-    def output_name(self, patch_id="out#1"):
+    def output_name(self, patch_id=f"{PortDirection.Output.value}#1"):
         return self.__outputs[patch_id].port_name()
 
     def output_name_match(self, patch_id, candidate_name):
@@ -153,7 +153,7 @@ class Midi(Plugin):
 
     def output_patches(self):
         patches = Midi.Config.get("outputDevices", None)
-        return patches if patches else { "out#1": Midi.Config.get("outputDevice", self.__default_output) }
+        return patches if patches else { f"{PortDirection.Output.value}#1": Midi.Config.get("outputDevice", self.__default_output) }
 
     def output_status(self, patch_id):
         if patch_id not in self.__outputs:

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -90,14 +90,6 @@ class Midi(Plugin):
         Midi.Config.changed.connect(self.__config_change)
         Midi.Config.updated.connect(self.__config_update)
 
-    @property
-    def input(self):
-        return self.__inputs[f"{PortDirection.Input.value}#1"]
-
-    @property
-    def output(self):
-        return self.__outputs[f"{PortDirection.Output.value}#1"]
-
     def add_exclusive_callback(self, patch_id, callback):
         if patch_id not in self.__inputs:
             return False
@@ -116,7 +108,7 @@ class Midi(Plugin):
             handler.exclusive_mode = False
             handler.received_exclusive.disconnect(callback)
 
-    def input_name(self, patch_id=f"{PortDirection.Input.value}#1"):
+    def input_name(self, patch_id):
         return self.__inputs[patch_id].port_name()
 
     def input_name_formatted(self, patch_id):
@@ -144,7 +136,7 @@ class Midi(Plugin):
             return PortStatus.DoesNotExist
         return PortStatus.Open if self.__inputs[patch_id].is_open() else PortStatus.Closed
 
-    def output_name(self, patch_id=f"{PortDirection.Output.value}#1"):
+    def output_name(self, patch_id):
         return self.__outputs[patch_id].port_name()
 
     def output_name_formatted(self, patch_id):

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -127,7 +127,7 @@ class Midi(Plugin):
     def input_patches(self):
         patches = {}
         for k, v in Midi.Config.get("inputDevices", {}).items():
-            if v:
+            if v is not None:
                 patches[k] = v
         return patches if patches else { f"{PortDirection.Input.value}#1": Midi.Config.get("inputDevice", self.__default_input) }
 
@@ -155,7 +155,7 @@ class Midi(Plugin):
     def output_patches(self):
         patches = {}
         for k, v in Midi.Config.get("outputDevices", {}).items():
-            if v:
+            if v is not None:
                 patches[k] = v
         return patches if patches else { f"{PortDirection.Output.value}#1": Midi.Config.get("outputDevice", self.__default_output) }
 
@@ -258,7 +258,7 @@ class Midi(Plugin):
                 elif device_name is None:
                     self._disconnect(patch_id, PortDirection.Input)
                 else:
-                    self.__inputs[patch_id].change_port(device_name)
+                    self.__inputs[patch_id].change_port(device_name or self.__default_input)
         elif key == "outputDevices":
             for patch_id, device_name in changeset.items():
                 if patch_id not in self.__outputs:
@@ -266,7 +266,7 @@ class Midi(Plugin):
                 elif device_name is None:
                     self._disconnect(patch_id, PortDirection.Output)
                 else:
-                    self.__outputs[patch_id].change_port(device_name)
+                    self.__outputs[patch_id].change_port(device_name or self.__default_output)
 
     def __config_update(self, diff):
         if "inputDevices" in diff:

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -101,6 +101,24 @@ class Midi(Plugin):
     def output(self):
         return self.__outputs["out#1"]
 
+    def add_exclusive_callback(self, patch_id, callback):
+        if patch_id not in self.__inputs:
+            return False
+        handler = self.__inputs[patch_id]
+        if handler.exclusive_mode:
+            return False
+        handler.exclusive_mode = True
+        handler.received_exclusive.connect(callback)
+        return True
+
+    def remove_exclusive_callback(self, patch_id, callback):
+        if patch_id not in self.__inputs:
+            return
+        handler = self.__inputs[patch_id]
+        if handler.received_exclusive.is_connected_to(callback):
+            handler.exclusive_mode = False
+            handler.received_exclusive.disconnect(callback)
+
     def input_name(self, patch_id="in#1"):
         return self.__inputs[patch_id].port_name()
 

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -68,14 +68,12 @@ class Midi(Plugin):
         self.received = Signal()
         self.__inputs = {}
         for patch_id, device_name in self.input_patches().items():
-            if device_name is not None:
-                self._connect(patch_id, device_name, PortDirection.Input)
+            self._connect(patch_id, device_name, PortDirection.Input)
 
         # Create output handlers and connect
         self.__outputs = {}
         for patch_id, device_name in self.output_patches().items():
-            if device_name is not None:
-                self._connect(patch_id, device_name, PortDirection.Output)
+            self._connect(patch_id, device_name, PortDirection.Output)
 
         # Monitor ports, for auto-reconnection.
         # Since current midi backends are not reliable on
@@ -132,7 +130,10 @@ class Midi(Plugin):
         return PortNameMatch.NoMatch
 
     def input_patches(self):
-        patches = Midi.Config.get("inputDevices", None)
+        patches = {}
+        for k, v in Midi.Config.get("inputDevices", {}).items():
+            if v:
+                patches[k] = v
         return patches if patches else { f"{PortDirection.Input.value}#1": Midi.Config.get("inputDevice", self.__default_input) }
 
     def input_status(self, patch_id):
@@ -154,7 +155,10 @@ class Midi(Plugin):
         return PortNameMatch.NoMatch
 
     def output_patches(self):
-        patches = Midi.Config.get("outputDevices", None)
+        patches = {}
+        for k, v in Midi.Config.get("outputDevices", {}).items():
+            if v:
+                patches[k] = v
         return patches if patches else { f"{PortDirection.Output.value}#1": Midi.Config.get("outputDevice", self.__default_output) }
 
     def output_status(self, patch_id):

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -129,7 +129,9 @@ class Midi(Plugin):
         for k, v in Midi.Config.get("inputDevices", {}).items():
             if v is not None:
                 patches[k] = v
-        return patches if patches else { f"{PortDirection.Input.value}#1": Midi.Config.get("inputDevice", self.__default_input) }
+        if not patches and Midi.Config.get("inputDevice", None) is not None:
+            patches = { f"{PortDirection.Input.value}#1": Midi.Config.get("inputDevice", self.__default_input) }
+        return patches
 
     def input_status(self, patch_id):
         if patch_id not in self.__inputs:
@@ -157,7 +159,9 @@ class Midi(Plugin):
         for k, v in Midi.Config.get("outputDevices", {}).items():
             if v is not None:
                 patches[k] = v
-        return patches if patches else { f"{PortDirection.Output.value}#1": Midi.Config.get("outputDevice", self.__default_output) }
+        if not patches and Midi.Config.get("outputDevice", None) is not None:
+            patches = { f"{PortDirection.Output.value}#1": Midi.Config.get("outputDevice", self.__default_output) }
+        return patches
 
     def output_status(self, patch_id):
         if patch_id not in self.__outputs:

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -25,7 +25,7 @@ from lisp.core.signal import Connection, Signal
 from lisp.plugins.midi.midi_cue import MidiCue
 from lisp.plugins.midi.midi_io import MIDIOutput, MIDIInput, MIDIBase
 from lisp.plugins.midi.midi_settings import MIDISettings
-from lisp.plugins.midi.midi_utils import midi_output_names, midi_input_names, PortDirection, PortNameMatch, PortStatus
+from lisp.plugins.midi.midi_utils import format_patch_name, midi_output_names, midi_input_names, PortDirection, PortNameMatch, PortStatus
 from lisp.plugins.midi.port_monitor import ALSAPortMonitor
 from lisp.ui.settings.app_configuration import AppConfigurationDialog
 from lisp.ui.ui_utils import translate
@@ -119,6 +119,9 @@ class Midi(Plugin):
     def input_name(self, patch_id=f"{PortDirection.Input.value}#1"):
         return self.__inputs[patch_id].port_name()
 
+    def input_name_formatted(self, patch_id):
+        return format_patch_name(patch_id, self.__inputs[patch_id].port_name())
+
     def input_name_match(self, patch_id, candidate_name):
         if patch_id not in self.__inputs:
             return PortNameMatch.NoMatch
@@ -143,6 +146,9 @@ class Midi(Plugin):
 
     def output_name(self, patch_id=f"{PortDirection.Output.value}#1"):
         return self.__outputs[patch_id].port_name()
+
+    def output_name_formatted(self, patch_id):
+        return format_patch_name(patch_id, self.__outputs[patch_id].port_name())
 
     def output_name_match(self, patch_id, candidate_name):
         if patch_id not in self.__outputs:

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -123,6 +123,12 @@ class Midi(Plugin):
             return PortStatus.DoesNotExist
         return PortStatus.Open if self.__outputs[patch_id].is_open() else PortStatus.Closed
 
+    def output_patch_exists(self, patch_id):
+        return patch_id in self.__outputs
+
+    def send(self, patch_id, message):
+        self.__outputs[patch_id].send(message)
+
     def _on_port_removed(self):
         avail_names = self.backend.get_input_names()
         for port in self.__inputs.values():

--- a/lisp/plugins/midi/midi.py
+++ b/lisp/plugins/midi/midi.py
@@ -25,7 +25,7 @@ from lisp.core.signal import Connection
 from lisp.plugins.midi.midi_cue import MidiCue
 from lisp.plugins.midi.midi_io import MIDIOutput, MIDIInput, MIDIBase
 from lisp.plugins.midi.midi_settings import MIDISettings
-from lisp.plugins.midi.midi_utils import midi_output_names, midi_input_names
+from lisp.plugins.midi.midi_utils import midi_output_names, midi_input_names, PortStatus
 from lisp.plugins.midi.port_monitor import ALSAPortMonitor
 from lisp.ui.settings.app_configuration import AppConfigurationDialog
 from lisp.ui.ui_utils import translate
@@ -106,12 +106,22 @@ class Midi(Plugin):
         patches = Midi.Config.get("inputDevices", None)
         return patches if patches else { "in#1": Midi.Config.get("inputDevice", self.__default_input) }
 
+    def input_status(self, patch_id):
+        if patch_id not in self.__inputs:
+            return PortStatus.DoesNotExist
+        return PortStatus.Open if self.__inputs[patch_id].is_open() else PortStatus.Closed
+
     def output_name(self, patch_id="out#1"):
         return self.__outputs[patch_id].port_name()
 
     def output_patches(self):
         patches = Midi.Config.get("outputDevices", None)
         return patches if patches else { "out#1": Midi.Config.get("outputDevice", self.__default_output) }
+
+    def output_status(self, patch_id):
+        if patch_id not in self.__outputs:
+            return PortStatus.DoesNotExist
+        return PortStatus.Open if self.__outputs[patch_id].is_open() else PortStatus.Closed
 
     def _on_port_removed(self):
         avail_names = self.backend.get_input_names()

--- a/lisp/plugins/midi/midi_cue.py
+++ b/lisp/plugins/midi/midi_cue.py
@@ -27,6 +27,7 @@ from lisp.plugins.midi.midi_utils import (
     midi_str_to_dict,
     midi_dict_to_str,
     midi_from_str,
+    PortDirection,
 )
 from lisp.plugins.midi.widgets import MIDIMessageEdit
 from lisp.ui.settings.cue_settings import CueSettingsRegistry
@@ -67,7 +68,7 @@ class MidiCueSettings(SettingsPage):
         self.setLayout(QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
 
-        self.midiEdit = MIDIMessageEdit(parent=self)
+        self.midiEdit = MIDIMessageEdit(PortDirection.Output, parent=self)
         self.layout().addWidget(self.midiEdit)
 
     def enableCheck(self, enabled):

--- a/lisp/plugins/midi/midi_cue.py
+++ b/lisp/plugins/midi/midi_cue.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 class MidiCue(Cue):
     Name = QT_TRANSLATE_NOOP("CueName", "MIDI Cue")
 
+    patch_id = Property(default="")
     message = Property(default="")
 
     def __init__(self, *args, **kwargs):
@@ -47,10 +48,15 @@ class MidiCue(Cue):
         self.__midi = get_plugin("Midi")
 
     def __start__(self, fade=False):
-        if self.message:
-            self.__midi.output.send(midi_from_str(self.message))
+        if self.message and self.patch_id:
+            self.__midi.send(self.patch_id, midi_from_str(self.message))
 
         return False
+
+    def update_properties(self, properties):
+        super().update_properties(properties)
+        if not self.__midi.output_patch_exists(properties.get("patch_id", "out#1")):
+            self._error()
 
 
 class MidiCueSettings(SettingsPage):
@@ -69,7 +75,10 @@ class MidiCueSettings(SettingsPage):
 
     def getSettings(self):
         if self.isGroupEnabled(self.midiEdit.msgGroup):
-            return {"message": midi_dict_to_str(self.midiEdit.getMessageDict())}
+            return {
+                "patch_id": self.midiEdit.getPatchId(),
+                "message": midi_dict_to_str(self.midiEdit.getMessageDict()),
+            }
 
         return {}
 
@@ -77,6 +86,9 @@ class MidiCueSettings(SettingsPage):
         message = settings.get("message", "")
         if message:
             self.midiEdit.setMessageDict(midi_str_to_dict(message))
+        patch_id = settings.get("patch_id", "")
+        if patch_id:
+            self.midiEdit.setPatchId(patch_id)
 
 
 CueSettingsRegistry().add(MidiCueSettings, MidiCue)

--- a/lisp/plugins/midi/midi_io.py
+++ b/lisp/plugins/midi/midi_io.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2019 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,11 +27,12 @@ logger = logging.getLogger(__name__)
 
 
 class MIDIBase(ABC):
-    def __init__(self, backend, port_name=None):
+    def __init__(self, backend, patch_id, port_name=None):
         """
         :param port_name: the port name
         """
         self._backend = backend
+        self._patch_id = patch_id
         self._port_name = port_name
         self._port = None
 
@@ -92,6 +93,7 @@ class MIDIInput(MIDIBase):
         super().__init__(*args)
 
         self.alternate_mode = False
+        self.received = Signal()
         self.new_message = Signal()
         self.new_message_alt = Signal()
 
@@ -121,4 +123,5 @@ class MIDIInput(MIDIBase):
         if self.alternate_mode:
             self.new_message_alt.emit(message)
         else:
+            self.received.emit(self._patch_id, message)
             self.new_message.emit(message)

--- a/lisp/plugins/midi/midi_io.py
+++ b/lisp/plugins/midi/midi_io.py
@@ -92,10 +92,10 @@ class MIDIInput(MIDIBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.alternate_mode = False
+        self.exclusive_mode = False
         self.received = Signal()
         self.new_message = Signal()
-        self.new_message_alt = Signal()
+        self.received_exclusive = Signal()
 
     def open(self):
         try:
@@ -120,8 +120,8 @@ class MIDIInput(MIDIBase):
                 }
             )
 
-        if self.alternate_mode:
-            self.new_message_alt.emit(message)
+        if self.exclusive_mode:
+            self.received_exclusive.emit(self._patch_id, message)
         else:
             self.received.emit(self._patch_id, message)
             self.new_message.emit(message)

--- a/lisp/plugins/midi/midi_io.py
+++ b/lisp/plugins/midi/midi_io.py
@@ -50,10 +50,11 @@ class MIDIBase(ABC):
         else:
             return self._port_name
 
-    def change_port(self, port_name):
+    def change_port(self, port_name, auto_open=True):
         self._port_name = port_name
         self.close()
-        self.open()
+        if auto_open:
+            self.open()
 
     @abstractmethod
     def open(self):

--- a/lisp/plugins/midi/midi_io_device_model.py
+++ b/lisp/plugins/midi/midi_io_device_model.py
@@ -1,0 +1,190 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from abc import abstractmethod
+import logging
+
+from PyQt5.QtCore import (
+    QAbstractTableModel,
+    QModelIndex,
+    Qt,
+    QT_TRANSLATE_NOOP,
+)
+
+from lisp.plugins import get_plugin
+from lisp.plugins.midi.midi_io import MIDIInput, MIDIOutput
+from lisp.plugins.midi.midi_utils import (
+    DEFAULT_DEVICE_NAME,
+    MAX_MIDI_DEVICES,
+    midi_input_names,
+    midi_output_names,
+    PortStatus,
+)
+from lisp.ui.ui_utils import translate
+
+
+logger = logging.getLogger(__name__)
+
+
+class MidiIODeviceModel(QAbstractTableModel):
+
+    def __init__(self):
+        super().__init__()
+
+        self.patches = []
+        self.columns = [
+            translate("MIDISettings", "#"),
+            translate("MIDISettings", "Device"),
+            translate("MIDISettings", "Status"),
+        ]
+        self.used_numids = []
+
+    def appendPatch(self, port_name=DEFAULT_DEVICE_NAME, numid=0):
+        if len(self.used_numids) == MAX_MIDI_DEVICES:
+            logger.warning("Arbitrary maximum number of MIDI devices reached.")
+            return
+
+        if numid == 0:
+            for candidate in range(1, MAX_MIDI_DEVICES + 1):
+                if candidate not in self.used_numids:
+                    numid = candidate
+                    break
+        elif numid in self.used_numids:
+            logger.warning("Provided ID already used. Refusing to add.")
+            return
+
+        self.used_numids.append(numid)
+        self.used_numids.sort()
+
+        row = self.used_numids.index(numid)
+        self.beginInsertRows(QModelIndex(), row, row)
+        patch = {
+            "id": numid,
+            "device": port_name,
+            "status": self.portStatus(numid, port_name),
+        }
+        self.patches.insert(row, patch)
+        self.endInsertRows()
+
+    def columnCount(self, parent=QModelIndex()):
+        return len(self.columns)
+
+    def data(self, index, role=Qt.DisplayRole):
+        if index.isValid():
+            column = index.column()
+            patch = self.patches[index.row()]
+
+            if role == Qt.TextAlignmentRole:
+                if column == 1:
+                    return Qt.AlignLeft | Qt.AlignVCenter
+                else:
+                    return Qt.AlignCenter
+
+            if role == Qt.DisplayRole:
+                if column == 0:
+                    return patch["id"]
+                elif column == 1:
+                    return patch["device"]
+                elif column == 2:
+                    return patch["status"].value
+
+            if role == Qt.EditRole and column == 1:
+                return patch["device"]
+
+    def deserialise(self, settings):
+        if isinstance(settings, str):
+            self.appendPatch(settings)
+
+    def flags(self, index):
+        column = index.column()
+        flags = Qt.ItemIsEnabled | Qt.ItemIsSelectable
+        if column == 1:
+            flags |= Qt.ItemIsEditable
+
+        return flags
+
+    def headerData(self, section, orientation, role=Qt.DisplayRole):
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            if section < len(self.columns):
+                return self.columns[section]
+            else:
+                return section + 1
+
+    @abstractmethod
+    def portStatus(self, numid, port_name):
+        pass
+
+    def rowCount(self, parent=QModelIndex()):
+        return len(self.patches)
+
+    def setData(self, index, value, role=Qt.EditRole):
+        if not index.isValid() or role != Qt.EditRole:
+            return False
+        
+        column = index.column()
+        if column != 1:
+            return False
+
+        row = index.row()
+        patch = self.patches[row]
+        patch["device"] = value
+
+        status_updated = self._updateStatus(row)
+        self.dataChanged.emit(
+            self.index(row, 1), # from top-left
+            self.index(row, 2 if status_updated else 1), # to bottom-right
+            [Qt.DisplayRole, Qt.EditRole],
+        )
+        return True
+
+    def _updateStatus(self, row):
+        patch = self.patches[row]
+        status = self.portStatus(patch["id"], patch["device"])
+        if status != patch["status"]:
+            patch["status"] = status
+            return True
+        return False
+
+    def updateStatuses(self):
+        for row in range(len(self.patches)):
+            if self._updateStatus(row):
+                self.dataChanged.emit(
+                    self.index(row, 2), # from top-left
+                    self.index(row, 2), # to bottom-right
+                    [Qt.DisplayRole],
+                )
+
+class MidiInputDeviceModel(MidiIODeviceModel):
+
+    def portStatus(self, numid, port_name):
+        patch_id = f"in#{numid}"
+        plugin = get_plugin("Midi")
+        status = plugin.input_status(patch_id)
+        if status is PortStatus.DoesNotExist or plugin.input_name(patch_id) != port_name:
+            return PortStatus.DoesNotExist
+        return status
+
+class MidiOutputDeviceModel(MidiIODeviceModel):
+
+    def portStatus(self, numid, port_name):
+        patch_id = f"out#{numid}"
+        plugin = get_plugin("Midi")
+        status = plugin.output_status(patch_id)
+        print(status)
+        if status is PortStatus.DoesNotExist or plugin.output_name(patch_id) != port_name:
+            return PortStatus.DoesNotExist
+        return status

--- a/lisp/plugins/midi/midi_io_device_model.py
+++ b/lisp/plugins/midi/midi_io_device_model.py
@@ -124,6 +124,8 @@ class MidiIODeviceModel(QAbstractTableModel):
         else:
             for patch_id, device in settings.items():
                 if device is not None:
+                    if device == "":
+                        device = DEFAULT_DEVICE_NAME
                     self.appendPatch(device, int(patch_id.split('#')[1]))
 
     def flags(self, index):
@@ -161,7 +163,8 @@ class MidiIODeviceModel(QAbstractTableModel):
     def serialise(self):
         patches = {}
         for row in self.patches:
-            patches[f'{self._direction.value}#{row["id"]}'] = row["device"]
+            patches[f'{self._direction.value}#{row["id"]}'] = \
+                '' if row["device"] == DEFAULT_DEVICE_NAME else row["device"]
         for numid in self.removed_numids:
             patches[f'{self._direction.value}#{numid}'] = None
         return patches

--- a/lisp/plugins/midi/midi_io_device_model.py
+++ b/lisp/plugins/midi/midi_io_device_model.py
@@ -115,6 +115,9 @@ class MidiIODeviceModel(QAbstractTableModel):
     def deserialise(self, settings):
         if isinstance(settings, str):
             self.appendPatch(settings)
+        else:
+            for patch_id, device in settings.items():
+                self.appendPatch(device, int(patch_id.split('#')[1]))
 
     def flags(self, index):
         column = index.column()
@@ -137,6 +140,10 @@ class MidiIODeviceModel(QAbstractTableModel):
 
     def rowCount(self, parent=QModelIndex()):
         return len(self.patches)
+
+    @abstractmethod
+    def serialise(self):
+        pass
 
     def setData(self, index, value, role=Qt.EditRole):
         if not index.isValid() or role != Qt.EditRole:
@@ -203,6 +210,12 @@ class MidiInputDeviceModel(MidiIODeviceModel):
         status = plugin.input_name_match(patch_id, port_name)
         return status
 
+    def serialise(self):
+        patches = {}
+        for row in self.patches:
+            patches[f'in#{row["id"]}'] = row["device"]
+        return patches
+
 class MidiOutputDeviceModel(MidiIODeviceModel):
 
     def portStatus(self, numid, port_name):
@@ -216,3 +229,9 @@ class MidiOutputDeviceModel(MidiIODeviceModel):
         plugin = get_plugin("Midi")
         status = plugin.output_name_match(patch_id, port_name)
         return status
+
+    def serialise(self):
+        patches = {}
+        for row in self.patches:
+            patches[f'out#{row["id"]}'] = row["device"]
+        return patches

--- a/lisp/plugins/midi/midi_io_device_view.py
+++ b/lisp/plugins/midi/midi_io_device_view.py
@@ -1,0 +1,65 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtWidgets import QHeaderView, QTableView
+
+from lisp.plugins.midi.midi_utils import (
+        DEFAULT_DEVICE_NAME,
+        MAX_MIDI_DEVICES,
+)
+from lisp.ui.qdelegates import (
+        ComboBoxDelegate,
+        LabelDelegate,
+        SpinBoxDelegate,
+)
+
+
+class MidiIODeviceView(QTableView):
+
+    def __init__(self, model, **kwargs):
+        super().__init__(**kwargs)
+
+        self.delegates = [
+            SpinBoxDelegate(minimum=1, maximum=MAX_MIDI_DEVICES),
+            ComboBoxDelegate(),
+            LabelDelegate(),
+        ]
+
+        self.setSelectionBehavior(QTableView.SelectRows)
+        self.setSelectionMode(QTableView.SingleSelection)
+
+        self.setShowGrid(False)
+        self.setAlternatingRowColors(True)
+
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.Fixed)
+
+        self.verticalHeader().setVisible(False)
+        self.verticalHeader().sectionResizeMode(QHeaderView.Fixed)
+        self.verticalHeader().setDefaultSectionSize(24)
+        self.verticalHeader().setHighlightSections(False)
+
+        self.setModel(model)
+
+        for column, delegate in enumerate(self.delegates):
+            self.setItemDelegateForColumn(column, delegate)
+
+        self.horizontalHeader().resizeSection(0, 32)
+        self.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        self.horizontalHeader().resizeSection(2, 64)
+
+    def setOptions(self, midi_devices):
+        self.delegates[1].options = [DEFAULT_DEVICE_NAME] + midi_devices

--- a/lisp/plugins/midi/midi_io_device_view.py
+++ b/lisp/plugins/midi/midi_io_device_view.py
@@ -73,14 +73,14 @@ class MidiIODeviceView(QTableView):
         self.delegates[1].options = [DEFAULT_DEVICE_NAME] + midi_devices
 
     def ensureOptionExists(self, entry):
-        if self.model().patches[0]["name_match"] is not PortNameMatch.ExactMatch:
+        if entry not in self.delegates[1].options:
             self.delegates[1].options.insert(1, entry)
 
     def ensureOptionsExist(self, options):
         new_options = []
         model = self.model()
         for patch_id, device_name in options.items():
-            if device_name is None or device_name in new_options or model.portNameMatch(patch_id.split('#')[1], device_name) is PortNameMatch.ExactMatch:
+            if device_name is None or device_name in new_options or device_name in self.delegates[1].options:
                 continue
             new_options.append(device_name)
         new_options.sort(reverse=True)

--- a/lisp/plugins/midi/midi_io_device_view.py
+++ b/lisp/plugins/midi/midi_io_device_view.py
@@ -80,7 +80,7 @@ class MidiIODeviceView(QTableView):
         new_options = []
         model = self.model()
         for patch_id, device_name in options.items():
-            if device_name is None or device_name in new_options or device_name in self.delegates[1].options:
+            if device_name is None or device_name == "" or device_name in new_options or device_name in self.delegates[1].options:
                 continue
             new_options.append(device_name)
         new_options.sort(reverse=True)

--- a/lisp/plugins/midi/midi_io_device_view.py
+++ b/lisp/plugins/midi/midi_io_device_view.py
@@ -70,3 +70,14 @@ class MidiIODeviceView(QTableView):
     def ensureOptionExists(self, entry):
         if self.model().patches[0]["name_match"] is not PortNameMatch.ExactMatch:
             self.delegates[1].options.insert(1, entry)
+
+    def ensureOptionsExist(self, options):
+        new_options = []
+        model = self.model()
+        for patch_id, device_name in options.items():
+            if device_name in new_options or model.portNameMatch(patch_id.split('#')[1], device_name) is PortNameMatch.ExactMatch:
+                continue
+            new_options.append(device_name)
+        new_options.sort(reverse=True)
+        for option in new_options:
+            self.delegates[1].options.insert(1, option)

--- a/lisp/plugins/midi/midi_io_device_view.py
+++ b/lisp/plugins/midi/midi_io_device_view.py
@@ -20,6 +20,7 @@ from PyQt5.QtWidgets import QHeaderView, QTableView
 from lisp.plugins.midi.midi_utils import (
         DEFAULT_DEVICE_NAME,
         MAX_MIDI_DEVICES,
+        PortNameMatch,
 )
 from lisp.ui.qdelegates import (
         ComboBoxDelegate,
@@ -63,3 +64,7 @@ class MidiIODeviceView(QTableView):
 
     def setOptions(self, midi_devices):
         self.delegates[1].options = [DEFAULT_DEVICE_NAME] + midi_devices
+
+    def ensureOptionExists(self, entry):
+        if self.model().patches[0]["name_match"] is not PortNameMatch.ExactMatch:
+            self.delegates[1].options.insert(1, entry)

--- a/lisp/plugins/midi/midi_io_device_view.py
+++ b/lisp/plugins/midi/midi_io_device_view.py
@@ -63,6 +63,8 @@ class MidiIODeviceView(QTableView):
         self.horizontalHeader().resizeSection(2, 64)
 
     def setOptions(self, midi_devices):
+        midi_devices = list(set(midi_devices)) # Remove duplicates
+        midi_devices.sort()
         self.delegates[1].options = [DEFAULT_DEVICE_NAME] + midi_devices
 
     def ensureOptionExists(self, entry):

--- a/lisp/plugins/midi/midi_settings.py
+++ b/lisp/plugins/midi/midi_settings.py
@@ -59,6 +59,8 @@ class MIDISettings(SettingsPage):
 
         self.inputRemButton = QPushButton(parent=self.inputGroup)
         self.inputRemButton.setEnabled(False)
+        self.inputView.hasSelectionChange.connect(self.inputRemButton.setEnabled)
+        self.inputRemButton.pressed.connect(self.inputView.removeSelectedPatch)
         self.inputGroup.layout().addWidget(self.inputRemButton, 1, 1)
 
         # Output patches
@@ -76,6 +78,8 @@ class MIDISettings(SettingsPage):
 
         self.outputRemButton = QPushButton(parent=self.outputGroup)
         self.outputRemButton.setEnabled(False)
+        self.outputView.hasSelectionChange.connect(self.outputRemButton.setEnabled)
+        self.outputRemButton.pressed.connect(self.outputView.removeSelectedPatch)
         self.outputGroup.layout().addWidget(self.outputRemButton, 1, 1)
 
         # Match by name

--- a/lisp/plugins/midi/midi_settings.py
+++ b/lisp/plugins/midi/midi_settings.py
@@ -164,6 +164,7 @@ class MIDISettings(SettingsPage):
                 self.inputCombo.setCurrentIndex(1)
 
             self.inputModel.deserialise(settings["inputDevice"])
+            self.inputView.ensureOptionExists(settings["inputDevice"])
 
         if settings["outputDevice"]:
             self.outputCombo.setCurrentText(settings["outputDevice"])
@@ -174,6 +175,7 @@ class MIDISettings(SettingsPage):
                 self.outputCombo.setCurrentIndex(1)
 
             self.outputModel.deserialise(settings["outputDevice"])
+            self.outputView.ensureOptionExists(settings["outputDevice"])
 
         self.nameMatchCheckBox.setChecked(
             settings.get("connectByNameMatch", False)

--- a/lisp/plugins/midi/midi_settings.py
+++ b/lisp/plugins/midi/midi_settings.py
@@ -38,46 +38,11 @@ from lisp.ui.ui_utils import translate
 
 class MIDISettings(SettingsPage):
     Name = QT_TRANSLATE_NOOP("SettingsPageName", "MIDI settings")
-    STATUS_SYMBOLS = {True: "✓", False: "×"}  # U+2713, U+00D7
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.setLayout(QVBoxLayout())
         self.layout().setAlignment(Qt.AlignTop)
-
-        self.portsGroup = QGroupBox(self)
-        self.portsGroup.setLayout(QGridLayout())
-        self.layout().addWidget(self.portsGroup)
-
-        # Input port
-        self.inputLabel = QLabel(self.portsGroup)
-        self.portsGroup.layout().addWidget(self.inputLabel, 0, 0, 2, 1)
-
-        self.inputCombo = QComboBox(self.portsGroup)
-        self.portsGroup.layout().addWidget(self.inputCombo, 0, 1)
-
-        self.inputStatus = QLabel(self.portsGroup)
-        self.inputStatus.setDisabled(True)
-        self.inputStatus.setText(f"[{MIDISettings.STATUS_SYMBOLS[False]}]")
-        self.portsGroup.layout().addWidget(self.inputStatus, 1, 1)
-
-        # Spacer
-        self.portsGroup.layout().addItem(QSpacerItem(0, 30), 2, 0, 2, 1)
-
-        # Output port
-        self.outputLabel = QLabel(self.portsGroup)
-        self.portsGroup.layout().addWidget(self.outputLabel, 3, 0, 2, 1)
-
-        self.outputCombo = QComboBox(self.portsGroup)
-        self.portsGroup.layout().addWidget(self.outputCombo, 3, 1)
-
-        self.outputStatus = QLabel(self.portsGroup)
-        self.outputStatus.setDisabled(True)
-        self.outputStatus.setText(f"[{MIDISettings.STATUS_SYMBOLS[False]}]")
-        self.portsGroup.layout().addWidget(self.outputStatus, 4, 1)
-
-        self.portsGroup.layout().setColumnStretch(0, 2)
-        self.portsGroup.layout().setColumnStretch(1, 3)
 
         # Input patches
         self.inputGroup = QGroupBox(self)
@@ -135,17 +100,6 @@ class MIDISettings(SettingsPage):
             self.updateTimer.start(2000)
 
     def retranslateUi(self):
-        self.portsGroup.setTitle(translate("MIDISettings", "MIDI devices"))
-        self.inputLabel.setText(translate("MIDISettings", "Input"))
-        self.outputLabel.setText(translate("MIDISettings", "Output"))
-
-        self.miscGroup.setTitle(translate("MIDISettings", "Misc options"))
-        self.nameMatchCheckBox.setText(
-            translate(
-                "MIDISettings", "Try to connect using only device/port name"
-            )
-        )
-
         self.inputGroup.setTitle(translate("MIDISettings", "MIDI Inputs"))
         self.inputAddButton.setText(translate("MIDISettings", "Add"))
         self.inputRemButton.setText(translate("MIDISettings", "Remove"))
@@ -154,38 +108,27 @@ class MIDISettings(SettingsPage):
         self.outputAddButton.setText(translate("MIDISettings", "Add"))
         self.outputRemButton.setText(translate("MIDISettings", "Remove"))
 
+        self.miscGroup.setTitle(translate("MIDISettings", "Misc options"))
+        self.nameMatchCheckBox.setText(
+            translate(
+                "MIDISettings", "Try to connect using only device/port name"
+            )
+        )
+
     def loadSettings(self, settings):
-        if settings["inputDevice"]:
-            self.inputCombo.setCurrentText(settings["inputDevice"])
-            if self.inputCombo.currentText() != settings["inputDevice"]:
-                self.inputCombo.insertItem(
-                    1, IconTheme.get("dialog-warning"), settings["inputDevice"]
-                )
-                self.inputCombo.setCurrentIndex(1)
-
-            if "inputDevices" not in settings:
-                self.inputModel.deserialise(settings["inputDevice"])
-                self.inputView.ensureOptionExists(settings["inputDevice"])
-
         if "inputDevices" in settings:
             self.inputModel.deserialise(settings["inputDevices"])
             self.inputView.ensureOptionsExist(settings["inputDevices"])
-
-        if settings["outputDevice"]:
-            self.outputCombo.setCurrentText(settings["outputDevice"])
-            if self.outputCombo.currentText() != settings["outputDevice"]:
-                self.outputCombo.insertItem(
-                    1, IconTheme.get("dialog-warning"), settings["outputDevice"]
-                )
-                self.outputCombo.setCurrentIndex(1)
-
-            if "outputDevices" not in settings:
-                self.outputModel.deserialise(settings["outputDevice"])
-                self.outputView.ensureOptionExists(settings["outputDevice"])
+        elif "inputDevice" in settings:
+            self.inputModel.deserialise(settings["inputDevice"])
+            self.inputView.ensureOptionExists(settings["inputDevice"])
 
         if "outputDevices" in settings:
             self.outputModel.deserialise(settings["outputDevices"])
             self.outputView.ensureOptionsExist(settings["outputDevices"])
+        elif "outputDevice" in settings:
+            self.outputModel.deserialise(settings["outputDevice"])
+            self.outputView.ensureOptionExists(settings["outputDevice"])
 
         self.nameMatchCheckBox.setChecked(
             settings.get("connectByNameMatch", False)
@@ -193,45 +136,18 @@ class MIDISettings(SettingsPage):
 
     def getSettings(self):
         if self.isEnabled():
-            input = self.inputCombo.currentText()
-            output = self.outputCombo.currentText()
-
             return {
-                "inputDevice": "" if input == "Default" else input,
-                "outputDevice": "" if output == "Default" else output,
                 "inputDevices": self.inputModel.serialise(),
                 "outputDevices": self.outputModel.serialise(),
                 "connectByNameMatch": self.nameMatchCheckBox.isChecked(),
             }
-
         return {}
 
-    @staticmethod
-    def portStatusSymbol(port):
-        return MIDISettings.STATUS_SYMBOLS.get(port.is_open(), "")
-
     def _updatePortsStatus(self):
-        midi = get_plugin("Midi")
-
-        self.inputStatus.setText(
-            f"[{self.portStatusSymbol(midi.input)}] {midi.input.port_name()}"
-        )
-        self.outputStatus.setText(
-            f"[{self.portStatusSymbol(midi.output)}] {midi.output.port_name()}"
-        )
-
         self.inputModel.updateStatuses()
         self.outputModel.updateStatuses()
 
     def _loadDevices(self):
-        self.inputCombo.clear()
-        self.inputCombo.addItems(["Default"])
-        self.inputCombo.addItems(midi_input_names())
-
-        self.outputCombo.clear()
-        self.outputCombo.addItems(["Default"])
-        self.outputCombo.addItems(midi_output_names())
-
         self.inputView.setOptions(midi_input_names())
         self.outputView.setOptions(midi_output_names())
 

--- a/lisp/plugins/midi/midi_settings.py
+++ b/lisp/plugins/midi/midi_settings.py
@@ -163,8 +163,13 @@ class MIDISettings(SettingsPage):
                 )
                 self.inputCombo.setCurrentIndex(1)
 
-            self.inputModel.deserialise(settings["inputDevice"])
-            self.inputView.ensureOptionExists(settings["inputDevice"])
+            if "inputDevices" not in settings:
+                self.inputModel.deserialise(settings["inputDevice"])
+                self.inputView.ensureOptionExists(settings["inputDevice"])
+
+        if "inputDevices" in settings:
+            self.inputModel.deserialise(settings["inputDevices"])
+            self.inputView.ensureOptionsExist(settings["inputDevices"])
 
         if settings["outputDevice"]:
             self.outputCombo.setCurrentText(settings["outputDevice"])
@@ -174,8 +179,13 @@ class MIDISettings(SettingsPage):
                 )
                 self.outputCombo.setCurrentIndex(1)
 
-            self.outputModel.deserialise(settings["outputDevice"])
-            self.outputView.ensureOptionExists(settings["outputDevice"])
+            if "outputDevices" not in settings:
+                self.outputModel.deserialise(settings["outputDevice"])
+                self.outputView.ensureOptionExists(settings["outputDevice"])
+
+        if "outputDevices" in settings:
+            self.outputModel.deserialise(settings["outputDevices"])
+            self.outputView.ensureOptionsExist(settings["outputDevices"])
 
         self.nameMatchCheckBox.setChecked(
             settings.get("connectByNameMatch", False)
@@ -189,6 +199,8 @@ class MIDISettings(SettingsPage):
             return {
                 "inputDevice": "" if input == "Default" else input,
                 "outputDevice": "" if output == "Default" else output,
+                "inputDevices": self.inputModel.serialise(),
+                "outputDevices": self.outputModel.serialise(),
                 "connectByNameMatch": self.nameMatchCheckBox.isChecked(),
             }
 

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -83,8 +83,8 @@ MAX_MIDI_DEVICES = 16 # 16 ins, 16 outs.
 
 
 class PortDirection(Enum):
-    Input = 0
-    Output = 1
+    Input = "in"
+    Output = "out"
 
 
 class PortNameMatch(Enum):

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -102,11 +102,12 @@ class PortStatus(Enum):
 
 
 def format_patch_name(patch_id, device_name):
-    return translate(
-        "MIDICue", "#{} :: {}"
-    ).format(
-        patch_id.split('#')[1], device_name
-    )
+    split_id = patch_id.split('#')
+    if split_id[0] == PortDirection.Input.value:
+        text = translate("MIDIInfo", "In {}: {}")
+    else:
+        text = translate("MIDIInfo", "Out {}: {}")
+    return text.format(split_id[1], device_name)
 
 
 def midi_backend() -> mido.Backend:

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -82,6 +82,11 @@ DEFAULT_DEVICE_NAME = "Default"
 MAX_MIDI_DEVICES = 16 # 16 ins, 16 outs.
 
 
+class PortDirection(Enum):
+    Input = 0
+    Output = 1
+
+
 class PortStatus(Enum):
     Open = "✓" # U+2713
     Closed = "×" # U+00D7

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -87,6 +87,12 @@ class PortDirection(Enum):
     Output = 1
 
 
+class PortNameMatch(Enum):
+    NoMatch = 0
+    ExactMatch = 1
+    FuzzyMatch = -1
+
+
 class PortStatus(Enum):
     Open = "✓" # U+2713
     Closed = "×" # U+00D7

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -21,6 +21,8 @@ from typing import Iterable
 import mido
 from PyQt5.QtCore import QT_TRANSLATE_NOOP
 
+from lisp.ui.ui_utils import translate
+
 MIDI_MSGS_SPEC = {
     "note_on": ["channel", "note", "velocity"],
     "note_off": ["channel", "note", "velocity"],
@@ -97,6 +99,14 @@ class PortStatus(Enum):
     Open = "✓" # U+2713
     Closed = "×" # U+00D7
     DoesNotExist = "~"
+
+
+def format_patch_name(patch_id, device_name):
+    return translate(
+        "MIDICue", "#{} :: {}"
+    ).format(
+        patch_id.split('#')[1], device_name
+    )
 
 
 def midi_backend() -> mido.Backend:

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2019 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2023 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
+from enum import Enum
 from typing import Iterable
 
 import mido
@@ -75,6 +76,16 @@ MIDI_ATTRS_NAME = {
     "pitch": QT_TRANSLATE_NOOP("MIDIMessageAttr", "Pitch"),
     "pos": QT_TRANSLATE_NOOP("MIDIMessageAttr", "Position"),
 }
+
+
+DEFAULT_DEVICE_NAME = "Default"
+MAX_MIDI_DEVICES = 16 # 16 ins, 16 outs.
+
+
+class PortStatus(Enum):
+    Open = "✓" # U+2713
+    Closed = "×" # U+00D7
+    DoesNotExist = "~"
 
 
 def midi_backend() -> mido.Backend:

--- a/lisp/plugins/midi/midi_utils.py
+++ b/lisp/plugins/midi/midi_utils.py
@@ -107,7 +107,7 @@ def format_patch_name(patch_id, device_name):
         text = translate("MIDIInfo", "In {}: {}")
     else:
         text = translate("MIDIInfo", "Out {}: {}")
-    return text.format(split_id[1], device_name)
+    return text.format(split_id[1], device_name or DEFAULT_DEVICE_NAME)
 
 
 def midi_backend() -> mido.Backend:

--- a/lisp/plugins/midi/widgets.py
+++ b/lisp/plugins/midi/widgets.py
@@ -48,7 +48,8 @@ class MIDIPatchCombo(QComboBox):
         self.__direction = direction
         self.__midi = get_plugin("Midi")
         for patch_id, device_name in self._patches().items():
-            self.addItem("", patch_id)
+            if device_name is not None:
+                self.addItem("", patch_id)
 
     def _patches(self):
         if self.__direction is PortDirection.Input:

--- a/lisp/plugins/midi/widgets.py
+++ b/lisp/plugins/midi/widgets.py
@@ -47,9 +47,8 @@ class MIDIPatchCombo(QComboBox):
         super().__init__(*args, **kwargs)
         self.__direction = direction
         self.__midi = get_plugin("Midi")
-        for patch_id, device_name in self._patches().items():
-            if device_name is not None:
-                self.addItem("", patch_id)
+        for patch_id in self._patches():
+            self.addItem("", patch_id)
 
     def _patches(self):
         if self.__direction is PortDirection.Input:

--- a/lisp/plugins/midi/widgets.py
+++ b/lisp/plugins/midi/widgets.py
@@ -33,6 +33,7 @@ from PyQt5.QtWidgets import (
 
 from lisp.plugins import get_plugin
 from lisp.plugins.midi.midi_utils import (
+    format_patch_name,
     MIDI_MSGS_SPEC,
     MIDI_ATTRS_SPEC,
     MIDI_MSGS_NAME,
@@ -59,11 +60,7 @@ class MIDIPatchCombo(QComboBox):
         for patch_id, device_name in self._patches().items():
             self.setItemText(
                 self.findData(patch_id),
-                translate(
-                    "MIDICue", "#{} :: {}"
-                ).format(
-                    patch_id.split('#')[1], device_name
-                )
+                format_patch_name(patch_id, device_name)
             )
 
 


### PR DESCRIPTION
This PR adds the ability to connect to more than one MIDI input and output at a time, allowing for listening to messages coming from more than one Interface or Port, and different MIDI cues sending messages to different locations.

Currently, there is a limit of 16 inputs and 16 outputs, but this could be raised or removed (although there's probably a maximum number that ALSA or Jack can handle).

The interface to define MIDI inputs and outputs now looks like:
![settings](https://github.com/FrancescoCeruti/linux-show-player/assets/2053873/fe8f064d-6389-49c7-b817-fdb800bb0e33)

With it now possible to select which of the predefined outputs is to be used for a MIDI cue:
![midi_cue](https://github.com/FrancescoCeruti/linux-show-player/assets/2053873/48bb90cd-ca12-4452-b9fc-f86d74552988)

And which of the predefined inputs should be listened to for Cue and Layout Controls:
![layout_controls](https://github.com/FrancescoCeruti/linux-show-player/assets/2053873/b0e98ca8-c0bf-4a75-a2cb-d52fab828f62)

(The Preferences dialog could probably do with being a little wider, but that's out of scope for this PR.)