### PR TITLE
Correctly save index column visibility

### DIFF
--- a/lisp/plugins/list_layout/layout.py
+++ b/lisp/plugins/list_layout/layout.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2017 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -344,7 +344,7 @@ class ListLayout(CueLayout):
 
     @index_column_visible.get
     def _get_index_column_visible(self):
-        return not self.show_index_action.isChecked()
+        return self.show_index_action.isChecked()
 
     @index_column_visible.set
     def _set_index_visible(self, visible):


### PR DESCRIPTION
At the moment, the "Show Index Column" option (in the "Layout" menu) is saved inverted to what it's set.

This means that if the Index Column is shown and the user then "saves" the showfile, the Column is saved as hidden, causing the column to not be shown when the showfile is next loaded. The reverse is also true.

This PR corrects this.