### PR TITLE
Basic Video support

### DIFF
--- a/lisp/backend/media_element.py
+++ b/lisp/backend/media_element.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,6 +36,7 @@ class MediaType(Enum):
     Audio = 0
     Video = 1
     AudioAndVideo = 2
+    Unknown = 4
 
 
 class MediaElement(HasProperties):

--- a/lisp/i18n/ts/en/action_cues.ts
+++ b/lisp/i18n/ts/en/action_cues.ts
@@ -4,22 +4,22 @@
   <context>
     <name>CollectionCue</name>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="110" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="111" />
       <source>Add</source>
       <translation>Add</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="111" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="112" />
       <source>Remove</source>
       <translation>Remove</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="180" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="186" />
       <source>Cue</source>
       <translation>Cue</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="181" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="187" />
       <source>Action</source>
       <translation>Action</translation>
     </message>
@@ -65,7 +65,7 @@
   <context>
     <name>CueCategory</name>
     <message>
-      <location filename="../../../plugins/action_cues/index_action_cue.py" line="40" />
+      <location filename="../../../plugins/action_cues/volume_control.py" line="55" />
       <source>Action cues</source>
       <translation type="unfinished" />
     </message>
@@ -73,9 +73,9 @@
   <context>
     <name>CueName</name>
     <message>
-      <location filename="../../../plugins/action_cues/seek_cue.py" line="40" />
-      <source>Seek Cue</source>
-      <translation>Seek Cue</translation>
+      <location filename="../../../plugins/action_cues/stop_all.py" line="29" />
+      <source>Stop-All</source>
+      <translation>Stop-All</translation>
     </message>
     <message>
       <location filename="../../../plugins/action_cues/collection_cue.py" line="43" />
@@ -83,9 +83,9 @@
       <translation>Collection Cue</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/stop_all.py" line="29" />
-      <source>Stop-All</source>
-      <translation>Stop-All</translation>
+      <location filename="../../../plugins/action_cues/seek_cue.py" line="40" />
+      <source>Seek Cue</source>
+      <translation>Seek Cue</translation>
     </message>
     <message>
       <location filename="../../../plugins/action_cues/command_cue.py" line="41" />
@@ -93,14 +93,14 @@
       <translation>Command Cue</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/volume_control.py" line="54" />
-      <source>Volume Control</source>
-      <translation>Volume Control</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/action_cues/index_action_cue.py" line="39" />
       <source>Index Action</source>
       <translation>Index Action</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/action_cues/volume_control.py" line="54" />
+      <source>Volume Control</source>
+      <translation>Volume Control</translation>
     </message>
   </context>
   <context>
@@ -167,19 +167,19 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../plugins/action_cues/seek_cue.py" line="59" />
-      <source>Seek Settings</source>
-      <translation>Seek Settings</translation>
+      <location filename="../../../plugins/action_cues/stop_all.py" line="43" />
+      <source>Stop Settings</source>
+      <translation>Stop Settings</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="108" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="109" />
       <source>Edit Collection</source>
       <translation>Edit Collection</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/stop_all.py" line="43" />
-      <source>Stop Settings</source>
-      <translation>Stop Settings</translation>
+      <location filename="../../../plugins/action_cues/seek_cue.py" line="59" />
+      <source>Seek Settings</source>
+      <translation>Seek Settings</translation>
     </message>
     <message>
       <location filename="../../../plugins/action_cues/command_cue.py" line="118" />
@@ -187,14 +187,14 @@
       <translation>Command</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/volume_control.py" line="129" />
-      <source>Volume Settings</source>
-      <translation>Volume Settings</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/action_cues/index_action_cue.py" line="65" />
       <source>Action Settings</source>
       <translation>Action Settings</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/action_cues/volume_control.py" line="129" />
+      <source>Volume Settings</source>
+      <translation>Volume Settings</translation>
     </message>
   </context>
   <context>

--- a/lisp/i18n/ts/en/controller.ts
+++ b/lisp/i18n/ts/en/controller.ts
@@ -178,12 +178,12 @@ do not forget to edit the path later.</source>
   <context>
     <name>ControllerSettings</name>
     <message>
-      <location filename="../../../plugins/controller/protocols/midi.py" line="122" />
+      <location filename="../../../plugins/controller/protocols/keyboard.py" line="79" />
       <source>Add</source>
       <translation>Add</translation>
     </message>
     <message>
-      <location filename="../../../plugins/controller/protocols/midi.py" line="123" />
+      <location filename="../../../plugins/controller/protocols/keyboard.py" line="80" />
       <source>Remove</source>
       <translation>Remove</translation>
     </message>
@@ -280,9 +280,9 @@ do not forget to edit the path later.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../../../plugins/controller/protocols/keyboard.py" line="44" />
-      <source>Keyboard Shortcuts</source>
-      <translation>Keyboard Shortcuts</translation>
+      <location filename="../../../plugins/controller/protocols/osc.py" line="230" />
+      <source>OSC Controls</source>
+      <translation type="unfinished" />
     </message>
     <message>
       <location filename="../../../plugins/controller/protocols/midi.py" line="64" />
@@ -290,9 +290,9 @@ do not forget to edit the path later.</source>
       <translation>MIDI Controls</translation>
     </message>
     <message>
-      <location filename="../../../plugins/controller/protocols/osc.py" line="230" />
-      <source>OSC Controls</source>
-      <translation type="unfinished" />
+      <location filename="../../../plugins/controller/protocols/keyboard.py" line="44" />
+      <source>Keyboard Shortcuts</source>
+      <translation>Keyboard Shortcuts</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/gst_backend.ts
+++ b/lisp/i18n/ts/en/gst_backend.ts
@@ -88,7 +88,7 @@
   <context>
     <name>CueCategory</name>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_backend.py" line="80" />
+      <location filename="../../../plugins/gst_backend/gst_backend.py" line="87" />
       <source>Media cues</source>
       <translation type="unfinished" />
     </message>
@@ -127,12 +127,17 @@
   <context>
     <name>GstBackend</name>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_backend.py" line="78" />
+      <location filename="../../../plugins/gst_backend/gst_backend.py" line="79" />
       <source>Audio cue (from file)</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_backend.py" line="131" />
+      <location filename="../../../plugins/gst_backend/gst_backend.py" line="85" />
+      <source>Video cue (from file)</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/gst_backend.py" line="148" />
       <source>Select media files</source>
       <translation type="unfinished" />
     </message>
@@ -140,7 +145,7 @@
   <context>
     <name>GstMediaError</name>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_media.py" line="254" />
+      <location filename="../../../plugins/gst_backend/gst_media.py" line="255" />
       <source>Cannot create pipeline element: "{}"</source>
       <translation type="unfinished" />
     </message>
@@ -156,7 +161,7 @@
   <context>
     <name>GstMediaWarning</name>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_media.py" line="248" />
+      <location filename="../../../plugins/gst_backend/gst_media.py" line="249" />
       <source>Invalid pipeline element: "{}"</source>
       <translation type="unfinished" />
     </message>
@@ -226,29 +231,19 @@
   <context>
     <name>MediaElementName</name>
     <message>
-      <location filename="../../../plugins/gst_backend/elements/speed.py" line="29" />
-      <source>Speed</source>
-      <translation>Speed</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/db_meter.py" line="30" />
-      <source>dB Meter</source>
-      <translation>dB Meter</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/audio_pan.py" line="29" />
-      <source>Audio Pan</source>
-      <translation>Audio Pan</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/gst_backend/elements/volume.py" line="35" />
       <source>Volume</source>
       <translation>Volume</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/elements/uri_input.py" line="35" />
-      <source>URI Input</source>
-      <translation>URI Input</translation>
+      <location filename="../../../plugins/gst_backend/elements/speed.py" line="29" />
+      <source>Speed</source>
+      <translation>Speed</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/equalizer10.py" line="29" />
+      <source>10 Bands Equalizer</source>
+      <translation>10 Bands Equalizer</translation>
     </message>
     <message>
       <location filename="../../../plugins/gst_backend/elements/jack_sink.py" line="35" />
@@ -256,14 +251,44 @@
       <translation>JACK Out</translation>
     </message>
     <message>
+      <location filename="../../../plugins/gst_backend/elements/uri_input.py" line="35" />
+      <source>URI Input</source>
+      <translation>URI Input</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/auto_src.py" line="27" />
+      <source>System Input</source>
+      <translation>System Input</translation>
+    </message>
+    <message>
       <location filename="../../../plugins/gst_backend/elements/pulse_sink.py" line="28" />
       <source>PulseAudio Out</source>
       <translation>PulseAudio Out</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/elements/auto_sink.py" line="28" />
-      <source>System Out</source>
-      <translation>System Out</translation>
+      <location filename="../../../plugins/gst_backend/elements/wayland_sink.py" line="29" />
+      <source>Wayland Video</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/audio_pan.py" line="29" />
+      <source>Audio Pan</source>
+      <translation>Audio Pan</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/pitch.py" line="29" />
+      <source>Pitch</source>
+      <translation>Pitch</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/alsa_sink.py" line="30" />
+      <source>ALSA Out</source>
+      <translation>ALSA Out</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/db_meter.py" line="30" />
+      <source>dB Meter</source>
+      <translation>dB Meter</translation>
     </message>
     <message>
       <location filename="../../../plugins/gst_backend/elements/audio_dynamic.py" line="31" />
@@ -276,29 +301,14 @@
       <translation>Custom Element</translation>
     </message>
     <message>
+      <location filename="../../../plugins/gst_backend/elements/auto_sink.py" line="28" />
+      <source>System Out</source>
+      <translation>System Out</translation>
+    </message>
+    <message>
       <location filename="../../../plugins/gst_backend/elements/preset_src.py" line="30" />
       <source>Preset Input</source>
       <translation>Preset Input</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/pitch.py" line="29" />
-      <source>Pitch</source>
-      <translation>Pitch</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/equalizer10.py" line="29" />
-      <source>10 Bands Equalizer</source>
-      <translation>10 Bands Equalizer</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/auto_src.py" line="27" />
-      <source>System Input</source>
-      <translation>System Input</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/alsa_sink.py" line="30" />
-      <source>ALSA Out</source>
-      <translation>ALSA Out</translation>
     </message>
   </context>
   <context>
@@ -325,14 +335,14 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_media_settings.py" line="36" />
-      <source>Media Settings</source>
-      <translation>Media Settings</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/gst_backend/gst_settings.py" line="27" />
       <source>GStreamer</source>
       <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/gst_media_settings.py" line="36" />
+      <source>Media Settings</source>
+      <translation>Media Settings</translation>
     </message>
     <message>
       <location filename="../../../plugins/gst_backend/config/alsa_sink.py" line="25" />
@@ -351,42 +361,42 @@
   <context>
     <name>UriInputSettings</name>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="83" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="85" />
       <source>Source</source>
       <translation>Source</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="84" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="86" />
       <source>Find File</source>
       <translation>Find File</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="85" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="87" />
       <source>Buffering</source>
       <translation>Buffering</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="87" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="89" />
       <source>Use Buffering</source>
       <translation>Use Buffering</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="90" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="92" />
       <source>Attempt download on network streams</source>
       <translation>Attempt download on network streams</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="93" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="95" />
       <source>Buffer size (-1 default value)</source>
       <translation>Buffer size (-1 default value)</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="130" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="132" />
       <source>Choose file</source>
       <translation>Choose file</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="132" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="134" />
       <source>All files</source>
       <translation>All files</translation>
     </message>
@@ -405,6 +415,14 @@
     </message>
   </context>
   <context>
+    <name>VideoPlayerSettings</name>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/wayland_sink.py" line="79" />
+      <source>Fullscreen</source>
+      <translation type="unfinished" />
+    </message>
+  </context>
+  <context>
     <name>VolumeSettings</name>
     <message>
       <location filename="../../../plugins/gst_backend/settings/volume.py" line="87" />
@@ -420,6 +438,19 @@
       <location filename="../../../plugins/gst_backend/settings/volume.py" line="92" />
       <source>Reset</source>
       <translation>Reset</translation>
+    </message>
+  </context>
+  <context>
+    <name>WaylandSinkSettings</name>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/wayland_sink.py" line="70" />
+      <source>Video device</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/wayland_sink.py" line="72" />
+      <source>To make your custom PCM objects appear correctly in this list requires adding a 'hint.description' line to them.</source>
+      <translation type="unfinished" />
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/lisp.ts
+++ b/lisp/i18n/ts/en/lisp.ts
@@ -352,26 +352,6 @@
   <context>
     <name>CueSettings</name>
     <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="64" />
-      <source>Interrupt fade</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="66" />
-      <source>Used globally when interrupting cues</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="72" />
-      <source>Fallback fade settings</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="75" />
-      <source>Used for fade-in and fade-out actions, for cues where fade duration is set to 0.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../../../ui/settings/cue_pages/cue_general.py" line="113" />
       <source>Start action</source>
       <translation>Start action</translation>
@@ -415,6 +395,26 @@
       <location filename="../../../ui/settings/cue_pages/cue_general.py" line="212" />
       <source>Next action</source>
       <translation>Next action</translation>
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="64" />
+      <source>Interrupt fade</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="66" />
+      <source>Used globally when interrupting cues</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="72" />
+      <source>Fallback fade settings</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="75" />
+      <source>Used for fade-in and fade-out actions, for cues where fade duration is set to 0.</source>
+      <translation type="unfinished" />
     </message>
   </context>
   <context>
@@ -526,16 +526,6 @@
   <context>
     <name>Logging</name>
     <message>
-      <location filename="../../../ui/logging/dialog.py" line="79" />
-      <source>Dismiss all</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/logging/dialog.py" line="86" />
-      <source>Show details</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../../../ui/logging/common.py" line="21" />
       <source>Debug</source>
       <translation>Debug</translation>
@@ -643,6 +633,16 @@
     <message>
       <location filename="../../../ui/logging/viewer.py" line="126" />
       <source>Showing {} of {} records</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/logging/dialog.py" line="79" />
+      <source>Dismiss all</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/logging/dialog.py" line="86" />
+      <source>Show details</source>
       <translation type="unfinished" />
     </message>
   </context>
@@ -939,31 +939,6 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../ui/settings/app_pages/plugins.py" line="36" />
-      <source>Plugins</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/general.py" line="38" />
-      <source>General</source>
-      <translation>General</translation>
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/layouts.py" line="26" />
-      <source>Layouts</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="27" />
-      <source>Cue Settings</source>
-      <translation>Cue Settings</translation>
-    </message>
-    <message>
-      <location filename="../../../ui/settings/cue_pages/media_cue.py" line="33" />
-      <source>Media Cue</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../../../ui/settings/cue_pages/cue_general.py" line="43" />
       <source>Cue</source>
       <translation>Cue</translation>
@@ -987,6 +962,31 @@
       <location filename="../../../ui/settings/cue_pages/cue_appearance.py" line="36" />
       <source>Appearance</source>
       <translation>Appearance</translation>
+    </message>
+    <message>
+      <location filename="../../../ui/settings/cue_pages/media_cue.py" line="33" />
+      <source>Media Cue</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/general.py" line="38" />
+      <source>General</source>
+      <translation>General</translation>
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/layouts.py" line="26" />
+      <source>Layouts</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/plugins.py" line="36" />
+      <source>Plugins</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="27" />
+      <source>Cue Settings</source>
+      <translation>Cue Settings</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/midi.ts
+++ b/lisp/i18n/ts/en/midi.ts
@@ -208,14 +208,14 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../plugins/midi/midi_settings.py" line="37" />
-      <source>MIDI settings</source>
-      <translation>MIDI settings</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/midi/midi_cue.py" line="57" />
       <source>MIDI Settings</source>
       <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/midi/midi_settings.py" line="37" />
+      <source>MIDI settings</source>
+      <translation>MIDI settings</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/presets.ts
+++ b/lisp/i18n/ts/en/presets.ts
@@ -17,14 +17,29 @@
   <context>
     <name>Presets</name>
     <message>
+      <location filename="../../../plugins/presets/presets_ui.py" line="355" />
+      <source>Presets</source>
+      <translation>Presets</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/presets/presets.py" line="73" />
+      <source>Apply to cue</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/presets/presets.py" line="75" />
+      <source>Apply to selected cues</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/presets/presets.py" line="79" />
+      <source>Save as preset</source>
+      <translation>Save as preset</translation>
+    </message>
+    <message>
       <location filename="../../../plugins/presets/presets_ui.py" line="66" />
       <source>Cannot scan presets</source>
       <translation>Cannot scan presets</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="68" />
-      <source>Presets</source>
-      <translation>Presets</translation>
     </message>
     <message>
       <location filename="../../../plugins/presets/presets_ui.py" line="423" />
@@ -125,21 +140,6 @@
       <location filename="../../../plugins/presets/presets_ui.py" line="312" />
       <source>Cannot create a cue from this preset: {}</source>
       <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="73" />
-      <source>Apply to cue</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="75" />
-      <source>Apply to selected cues</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="79" />
-      <source>Save as preset</source>
-      <translation>Save as preset</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/replay_gain.ts
+++ b/lisp/i18n/ts/en/replay_gain.ts
@@ -4,24 +4,9 @@
   <context>
     <name>ReplayGain</name>
     <message>
-      <location filename="../../../plugins/replay_gain/gain_ui.py" line="111" />
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="50" />
       <source>ReplayGain / Normalization</source>
       <translation>ReplayGain / Normalization</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/replay_gain/replay_gain.py" line="55" />
-      <source>Calculate</source>
-      <translation>Calculate</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/replay_gain/replay_gain.py" line="60" />
-      <source>Reset all</source>
-      <translation>Reset all</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/replay_gain/replay_gain.py" line="66" />
-      <source>Reset selected</source>
-      <translation>Reset selected</translation>
     </message>
     <message>
       <location filename="../../../plugins/replay_gain/gain_ui.py" line="113" />
@@ -47,6 +32,21 @@
       <location filename="../../../plugins/replay_gain/gain_ui.py" line="145" />
       <source>Processing files ...</source>
       <translation>Processing files ...</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="55" />
+      <source>Calculate</source>
+      <translation>Calculate</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="60" />
+      <source>Reset all</source>
+      <translation>Reset all</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="66" />
+      <source>Reset selected</source>
+      <translation>Reset selected</translation>
     </message>
   </context>
   <context>

--- a/lisp/plugins/gst_backend/default.json
+++ b/lisp/plugins/gst_backend/default.json
@@ -1,5 +1,7 @@
 {
-  "_version_": "2",
+  "_version_": "3",
   "_enabled_": true,
+  "audio-pipeline": ["Volume", "Equalizer10", "DbMeter", "AutoSink"],
+  "video-pipeline": ["Volume", "DbMeter", "Equalizer10", "WaylandSink", "AutoSink"],
   "pipeline": ["Volume", "Equalizer10", "DbMeter", "AutoSink"]
 }

--- a/lisp/plugins/gst_backend/elements/wayland_sink.py
+++ b/lisp/plugins/gst_backend/elements/wayland_sink.py
@@ -1,0 +1,43 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtCore import QT_TRANSLATE_NOOP
+
+from lisp.backend.media_element import ElementType, MediaType
+from lisp.plugins.gst_backend.gi_repository import Gst
+from lisp.plugins.gst_backend.gst_element import GstMediaElement
+from lisp.plugins.gst_backend.gst_properties import GstProperty
+
+
+class WaylandSink(GstMediaElement):
+    ElementType = ElementType.Output
+    MediaType = MediaType.Video
+    Name = QT_TRANSLATE_NOOP("MediaElementName", "Wayland Video")
+
+    def __init__(self, pipeline):
+        super().__init__(pipeline)
+        
+        device = GstProperty("wayland_sink", "display", default="wayland-0")
+        fullscreen = GstProperty("wayland_sink", "fullscreen", default=True)
+
+        self.wayland_sink = Gst.ElementFactory.make("waylandsink", "wayland_sink")
+        # Need to set this explicitly for some reason
+        # self.wayland_sink.set_property("fullscreen", fullscreen)
+        self.pipeline.add(self.wayland_sink)
+
+    def sink(self):
+        return self.wayland_sink

--- a/lisp/plugins/gst_backend/gst_element.py
+++ b/lisp/plugins/gst_backend/gst_element.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -121,8 +121,6 @@ class GstMediaElements(Collection, HasInstanceProperties):
         """
         :type element: lisp.backend.media_element.MediaElement
         """
-        if self.elements:
-            self.elements[-1].link(element)
         self.elements.append(element)
 
         # Add a property for the new added element

--- a/lisp/plugins/gst_backend/gst_media_cue.py
+++ b/lisp/plugins/gst_backend/gst_media_cue.py
@@ -1,6 +1,6 @@
 # This file is part of Linux Show Player
 #
-# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
 #
 # Linux Show Player is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
+from lisp.backend.media_element import MediaType
 from lisp.core.properties import Property
 from lisp.cues.media_cue import MediaCue
 from lisp.plugins.gst_backend.gst_media import GstMedia
@@ -43,10 +44,11 @@ class GstCueFactory:
             return [self.input] + self.base_pipeline
 
 
-class UriAudioCueFactory(GstCueFactory):
-    def __init__(self, base_pipeline):
+class UriMediaCueFactory(GstCueFactory):
+    def __init__(self, base_pipeline, media_type):
         super().__init__(base_pipeline)
         self.input = "UriInput"
+        self.media_type = media_type
 
     def __call__(self, app, id=None, uri=None):
         cue = super().__call__(app, id=id)

--- a/lisp/plugins/gst_backend/settings/wayland_sink.py
+++ b/lisp/plugins/gst_backend/settings/wayland_sink.py
@@ -1,0 +1,110 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QGroupBox,
+    QComboBox,
+    QLabel,
+    QCheckBox,
+    QVBoxLayout,
+)
+
+from lisp.plugins.gst_backend import GstBackend
+from lisp.plugins.gst_backend.elements.wayland_sink import WaylandSink
+from lisp.ui.settings.pages import SettingsPage
+from lisp.ui.ui_utils import translate
+
+
+class WaylandSinkSettings(SettingsPage):
+    ELEMENT = WaylandSink
+    Name = ELEMENT.Name
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+
+        self.devices = {
+            'wayland-0': 'wayland-0',
+            'wayland-1': 'wayland-1'
+        }
+        # self.discover_output_wayland_devices()
+
+        self.deviceGroup = QGroupBox(self)
+        self.deviceGroup.setGeometry(0, 0, self.width(), 100)
+        self.deviceGroup.setLayout(QVBoxLayout())
+        self.layout().addWidget(self.deviceGroup)
+
+        self.deviceComboBox = QComboBox(self.deviceGroup)
+        for name, description in self.devices.items():
+            self.deviceComboBox.addItem(description, name)
+
+        self.deviceGroup.layout().addWidget(self.deviceComboBox)
+
+        self.helpLabel = QLabel(self.deviceGroup)
+        self.helpLabel.setWordWrap(True)
+        self.deviceGroup.layout().addWidget(self.helpLabel)
+
+        self.fullScreen = QCheckBox(self.deviceGroup)
+        self.deviceGroup.layout().addWidget(self.fullScreen)
+
+        self.retranslateUi()
+
+    def retranslateUi(self):
+        self.deviceGroup.setTitle(translate("WaylandSinkSettings", "Video device"))
+        self.helpLabel.setText(
+            translate(
+                "WaylandSinkSettings",
+                "To make your custom PCM objects appear correctly in this list "
+                "requires adding a 'hint.description' line to them.",
+            )
+        )
+        self.fullScreen.setText(
+            translate("VideoPlayerSettings", "Fullscreen")
+        )
+
+    def enableCheck(self, enabled):
+        self.setGroupEnabled(self.deviceGroup, enabled)
+
+    def loadSettings(self, settings):
+        device = settings.get(
+            "device",
+            GstBackend.Config.get("wayland_device", "wayland-0"),
+        )
+
+        self.deviceComboBox.setCurrentText(
+            self.devices.get(device, self.devices.get('wayland-0'))
+        )
+
+        self.fullScreen.setChecked(
+            GstBackend.Config.get("fullscreen", True)
+        )
+
+    def getSettings(self):
+        if self.isGroupEnabled(self.deviceGroup):
+            return {
+                "device": self.deviceComboBox.currentData(),
+                "fullscreen": self.fullScreen.isChecked()
+                }
+
+        return {}
+
+    def discover_output_wayland_devices(self):
+        self.devices = {}
+


### PR DESCRIPTION
# Basic Video Support

This PR provides a working POC (proof-of-concept) demonstrating native video playback capabilities inside Linux Show Player. In the final phase it will provide a basic implementation of video support which should be good enough for many shows (and which should ultimately address issue #3). 

In the POC Phase (Phase I) LSP uses the WaylandSink for full-sized video playback on the main display. The video can be set to play in `fullscreen`. In Phase II a choice of video sinks may be presented to suit the environment.

Code changes are entirely within the `gst_backend` plugin.

## What's working

- add a video cue (right-click context menu)
- add a video cue (drag & drop)
- video playback on **main display only**
- fullscreen playback on main display
- seek/pause/etc
- audio playback
- audio pipeline (db meters, etc)
- video duration

## TODO
- video playback on external monitor/projector
- more robust video sink selection
- hide mouse during playback
- fade video opacity
- adjust other video parameters (brightness, contrast, etc)
- image transform (keystone)
- video playback in a window (audition)
- video thumbnail