### PR TITLE
Audio filter plugins

### DIFF
--- a/lisp/i18n/ts/en/action_cues.ts
+++ b/lisp/i18n/ts/en/action_cues.ts
@@ -4,22 +4,22 @@
   <context>
     <name>CollectionCue</name>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="110" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="111" />
       <source>Add</source>
       <translation>Add</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="111" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="112" />
       <source>Remove</source>
       <translation>Remove</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="180" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="186" />
       <source>Cue</source>
       <translation>Cue</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="181" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="187" />
       <source>Action</source>
       <translation>Action</translation>
     </message>
@@ -65,7 +65,7 @@
   <context>
     <name>CueCategory</name>
     <message>
-      <location filename="../../../plugins/action_cues/index_action_cue.py" line="40" />
+      <location filename="../../../plugins/action_cues/volume_control.py" line="55" />
       <source>Action cues</source>
       <translation type="unfinished" />
     </message>
@@ -73,9 +73,9 @@
   <context>
     <name>CueName</name>
     <message>
-      <location filename="../../../plugins/action_cues/seek_cue.py" line="40" />
-      <source>Seek Cue</source>
-      <translation>Seek Cue</translation>
+      <location filename="../../../plugins/action_cues/stop_all.py" line="29" />
+      <source>Stop-All</source>
+      <translation>Stop-All</translation>
     </message>
     <message>
       <location filename="../../../plugins/action_cues/collection_cue.py" line="43" />
@@ -83,9 +83,9 @@
       <translation>Collection Cue</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/stop_all.py" line="29" />
-      <source>Stop-All</source>
-      <translation>Stop-All</translation>
+      <location filename="../../../plugins/action_cues/seek_cue.py" line="40" />
+      <source>Seek Cue</source>
+      <translation>Seek Cue</translation>
     </message>
     <message>
       <location filename="../../../plugins/action_cues/command_cue.py" line="41" />
@@ -93,14 +93,14 @@
       <translation>Command Cue</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/volume_control.py" line="54" />
-      <source>Volume Control</source>
-      <translation>Volume Control</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/action_cues/index_action_cue.py" line="39" />
       <source>Index Action</source>
       <translation>Index Action</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/action_cues/volume_control.py" line="54" />
+      <source>Volume Control</source>
+      <translation>Volume Control</translation>
     </message>
   </context>
   <context>
@@ -167,19 +167,19 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../plugins/action_cues/seek_cue.py" line="59" />
-      <source>Seek Settings</source>
-      <translation>Seek Settings</translation>
+      <location filename="../../../plugins/action_cues/stop_all.py" line="43" />
+      <source>Stop Settings</source>
+      <translation>Stop Settings</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/collection_cue.py" line="108" />
+      <location filename="../../../plugins/action_cues/collection_cue.py" line="109" />
       <source>Edit Collection</source>
       <translation>Edit Collection</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/stop_all.py" line="43" />
-      <source>Stop Settings</source>
-      <translation>Stop Settings</translation>
+      <location filename="../../../plugins/action_cues/seek_cue.py" line="59" />
+      <source>Seek Settings</source>
+      <translation>Seek Settings</translation>
     </message>
     <message>
       <location filename="../../../plugins/action_cues/command_cue.py" line="118" />
@@ -187,14 +187,14 @@
       <translation>Command</translation>
     </message>
     <message>
-      <location filename="../../../plugins/action_cues/volume_control.py" line="129" />
-      <source>Volume Settings</source>
-      <translation>Volume Settings</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/action_cues/index_action_cue.py" line="65" />
       <source>Action Settings</source>
       <translation>Action Settings</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/action_cues/volume_control.py" line="129" />
+      <source>Volume Settings</source>
+      <translation>Volume Settings</translation>
     </message>
   </context>
   <context>

--- a/lisp/i18n/ts/en/controller.ts
+++ b/lisp/i18n/ts/en/controller.ts
@@ -178,12 +178,12 @@ do not forget to edit the path later.</source>
   <context>
     <name>ControllerSettings</name>
     <message>
-      <location filename="../../../plugins/controller/protocols/midi.py" line="122" />
+      <location filename="../../../plugins/controller/protocols/keyboard.py" line="79" />
       <source>Add</source>
       <translation>Add</translation>
     </message>
     <message>
-      <location filename="../../../plugins/controller/protocols/midi.py" line="123" />
+      <location filename="../../../plugins/controller/protocols/keyboard.py" line="80" />
       <source>Remove</source>
       <translation>Remove</translation>
     </message>
@@ -280,9 +280,9 @@ do not forget to edit the path later.</source>
       <translation type="unfinished" />
     </message>
     <message>
-      <location filename="../../../plugins/controller/protocols/keyboard.py" line="44" />
-      <source>Keyboard Shortcuts</source>
-      <translation>Keyboard Shortcuts</translation>
+      <location filename="../../../plugins/controller/protocols/osc.py" line="230" />
+      <source>OSC Controls</source>
+      <translation type="unfinished" />
     </message>
     <message>
       <location filename="../../../plugins/controller/protocols/midi.py" line="64" />
@@ -290,9 +290,9 @@ do not forget to edit the path later.</source>
       <translation>MIDI Controls</translation>
     </message>
     <message>
-      <location filename="../../../plugins/controller/protocols/osc.py" line="230" />
-      <source>OSC Controls</source>
-      <translation type="unfinished" />
+      <location filename="../../../plugins/controller/protocols/keyboard.py" line="44" />
+      <source>Keyboard Shortcuts</source>
+      <translation>Keyboard Shortcuts</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/gst_backend.ts
+++ b/lisp/i18n/ts/en/gst_backend.ts
@@ -86,6 +86,69 @@
     </message>
   </context>
   <context>
+    <name>BandpassFilterSettings</name>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="40" />
+      <source>Bandpass Filter</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="69" />
+      <source>Lower Frequency</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="92" />
+      <source>Upper Frequency</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="98" />
+      <source>Hamming</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="101" />
+      <source>Blackman</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="104" />
+      <source>Gaussian</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="107" />
+      <source>Cosine</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="110" />
+      <source>Hann</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="118" />
+      <source>Window Mode</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="124" />
+      <source>Band-Pass</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="127" />
+      <source>Band-Reject</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/bandpass_filter.py" line="135" />
+      <source>Filter Mode</source>
+      <translation type="unfinished" />
+    </message>
+  </context>
+  <context>
     <name>CueCategory</name>
     <message>
       <location filename="../../../plugins/gst_backend/gst_backend.py" line="80" />
@@ -183,6 +246,49 @@
     </message>
   </context>
   <context>
+    <name>HighpassFilterSettings</name>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="47" />
+      <source>Highpass Settings</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="76" />
+      <source>High-pass Frequency</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="81" />
+      <source>Hamming</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="84" />
+      <source>Blackman</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="87" />
+      <source>Gaussian</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="90" />
+      <source>Cosine</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="93" />
+      <source>Hann</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/highpass_filter.py" line="101" />
+      <source>Windowing Mode</source>
+      <translation type="unfinished" />
+    </message>
+  </context>
+  <context>
     <name>JackSinkError</name>
     <message>
       <location filename="../../../plugins/gst_backend/elements/jack_sink.py" line="136" />
@@ -224,31 +330,70 @@
     </message>
   </context>
   <context>
+    <name>LowpassFilterSettings</name>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="47" />
+      <source>Lowpass Settings</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="75" />
+      <source>Low-pass Frequency</source>
+      <comment>Low-pass Frequency</comment>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="80" />
+      <source>Hamming</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="83" />
+      <source>Blackman</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="86" />
+      <source>Gaussian</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="89" />
+      <source>Cosine</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="92" />
+      <source>Hann</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/settings/lowpass_filter.py" line="100" />
+      <source>Windowing Mode</source>
+      <translation type="unfinished" />
+    </message>
+  </context>
+  <context>
     <name>MediaElementName</name>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/speed.py" line="29" />
-      <source>Speed</source>
-      <translation>Speed</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/db_meter.py" line="30" />
-      <source>dB Meter</source>
-      <translation>dB Meter</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/audio_pan.py" line="29" />
-      <source>Audio Pan</source>
-      <translation>Audio Pan</translation>
-    </message>
     <message>
       <location filename="../../../plugins/gst_backend/elements/volume.py" line="35" />
       <source>Volume</source>
       <translation>Volume</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/elements/uri_input.py" line="35" />
-      <source>URI Input</source>
-      <translation>URI Input</translation>
+      <location filename="../../../plugins/gst_backend/elements/speed.py" line="29" />
+      <source>Speed</source>
+      <translation>Speed</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/equalizer10.py" line="29" />
+      <source>10 Bands Equalizer</source>
+      <translation>10 Bands Equalizer</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/highpass_filter.py" line="30" />
+      <source>Highpass Filter</source>
+      <translation type="unfinished" />
     </message>
     <message>
       <location filename="../../../plugins/gst_backend/elements/jack_sink.py" line="35" />
@@ -256,14 +401,49 @@
       <translation>JACK Out</translation>
     </message>
     <message>
+      <location filename="../../../plugins/gst_backend/elements/uri_input.py" line="35" />
+      <source>URI Input</source>
+      <translation>URI Input</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/auto_src.py" line="27" />
+      <source>System Input</source>
+      <translation>System Input</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/lowpass_filter.py" line="31" />
+      <source>Lowpass Filter</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
       <location filename="../../../plugins/gst_backend/elements/pulse_sink.py" line="28" />
       <source>PulseAudio Out</source>
       <translation>PulseAudio Out</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/elements/auto_sink.py" line="28" />
-      <source>System Out</source>
-      <translation>System Out</translation>
+      <location filename="../../../plugins/gst_backend/elements/audio_pan.py" line="29" />
+      <source>Audio Pan</source>
+      <translation>Audio Pan</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/bandpass_filter.py" line="29" />
+      <source>Bandpass filter</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/pitch.py" line="29" />
+      <source>Pitch</source>
+      <translation>Pitch</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/alsa_sink.py" line="30" />
+      <source>ALSA Out</source>
+      <translation>ALSA Out</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/elements/db_meter.py" line="30" />
+      <source>dB Meter</source>
+      <translation>dB Meter</translation>
     </message>
     <message>
       <location filename="../../../plugins/gst_backend/elements/audio_dynamic.py" line="31" />
@@ -276,29 +456,14 @@
       <translation>Custom Element</translation>
     </message>
     <message>
+      <location filename="../../../plugins/gst_backend/elements/auto_sink.py" line="28" />
+      <source>System Out</source>
+      <translation>System Out</translation>
+    </message>
+    <message>
       <location filename="../../../plugins/gst_backend/elements/preset_src.py" line="30" />
       <source>Preset Input</source>
       <translation>Preset Input</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/pitch.py" line="29" />
-      <source>Pitch</source>
-      <translation>Pitch</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/equalizer10.py" line="29" />
-      <source>10 Bands Equalizer</source>
-      <translation>10 Bands Equalizer</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/auto_src.py" line="27" />
-      <source>System Input</source>
-      <translation>System Input</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/gst_backend/elements/alsa_sink.py" line="30" />
-      <source>ALSA Out</source>
-      <translation>ALSA Out</translation>
     </message>
   </context>
   <context>
@@ -325,14 +490,14 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../plugins/gst_backend/gst_media_settings.py" line="36" />
-      <source>Media Settings</source>
-      <translation>Media Settings</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/gst_backend/gst_settings.py" line="27" />
       <source>GStreamer</source>
       <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/gst_backend/gst_media_settings.py" line="36" />
+      <source>Media Settings</source>
+      <translation>Media Settings</translation>
     </message>
     <message>
       <location filename="../../../plugins/gst_backend/config/alsa_sink.py" line="25" />
@@ -351,42 +516,42 @@
   <context>
     <name>UriInputSettings</name>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="83" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="85" />
       <source>Source</source>
       <translation>Source</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="84" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="86" />
       <source>Find File</source>
       <translation>Find File</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="85" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="87" />
       <source>Buffering</source>
       <translation>Buffering</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="87" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="89" />
       <source>Use Buffering</source>
       <translation>Use Buffering</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="90" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="92" />
       <source>Attempt download on network streams</source>
       <translation>Attempt download on network streams</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="93" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="95" />
       <source>Buffer size (-1 default value)</source>
       <translation>Buffer size (-1 default value)</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="130" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="132" />
       <source>Choose file</source>
       <translation>Choose file</translation>
     </message>
     <message>
-      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="132" />
+      <location filename="../../../plugins/gst_backend/settings/uri_input.py" line="134" />
       <source>All files</source>
       <translation>All files</translation>
     </message>

--- a/lisp/i18n/ts/en/lisp.ts
+++ b/lisp/i18n/ts/en/lisp.ts
@@ -352,26 +352,6 @@
   <context>
     <name>CueSettings</name>
     <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="64" />
-      <source>Interrupt fade</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="66" />
-      <source>Used globally when interrupting cues</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="72" />
-      <source>Fallback fade settings</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="75" />
-      <source>Used for fade-in and fade-out actions, for cues where fade duration is set to 0.</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../../../ui/settings/cue_pages/cue_general.py" line="113" />
       <source>Start action</source>
       <translation>Start action</translation>
@@ -415,6 +395,26 @@
       <location filename="../../../ui/settings/cue_pages/cue_general.py" line="212" />
       <source>Next action</source>
       <translation>Next action</translation>
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="64" />
+      <source>Interrupt fade</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="66" />
+      <source>Used globally when interrupting cues</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="72" />
+      <source>Fallback fade settings</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="75" />
+      <source>Used for fade-in and fade-out actions, for cues where fade duration is set to 0.</source>
+      <translation type="unfinished" />
     </message>
   </context>
   <context>
@@ -526,16 +526,6 @@
   <context>
     <name>Logging</name>
     <message>
-      <location filename="../../../ui/logging/dialog.py" line="79" />
-      <source>Dismiss all</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/logging/dialog.py" line="86" />
-      <source>Show details</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../../../ui/logging/common.py" line="21" />
       <source>Debug</source>
       <translation>Debug</translation>
@@ -643,6 +633,16 @@
     <message>
       <location filename="../../../ui/logging/viewer.py" line="126" />
       <source>Showing {} of {} records</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/logging/dialog.py" line="79" />
+      <source>Dismiss all</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/logging/dialog.py" line="86" />
+      <source>Show details</source>
       <translation type="unfinished" />
     </message>
   </context>
@@ -939,31 +939,6 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../ui/settings/app_pages/plugins.py" line="36" />
-      <source>Plugins</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/general.py" line="38" />
-      <source>General</source>
-      <translation>General</translation>
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/layouts.py" line="26" />
-      <source>Layouts</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../ui/settings/app_pages/cue.py" line="27" />
-      <source>Cue Settings</source>
-      <translation>Cue Settings</translation>
-    </message>
-    <message>
-      <location filename="../../../ui/settings/cue_pages/media_cue.py" line="33" />
-      <source>Media Cue</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
       <location filename="../../../ui/settings/cue_pages/cue_general.py" line="43" />
       <source>Cue</source>
       <translation>Cue</translation>
@@ -987,6 +962,31 @@
       <location filename="../../../ui/settings/cue_pages/cue_appearance.py" line="36" />
       <source>Appearance</source>
       <translation>Appearance</translation>
+    </message>
+    <message>
+      <location filename="../../../ui/settings/cue_pages/media_cue.py" line="33" />
+      <source>Media Cue</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/general.py" line="38" />
+      <source>General</source>
+      <translation>General</translation>
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/layouts.py" line="26" />
+      <source>Layouts</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/plugins.py" line="36" />
+      <source>Plugins</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../ui/settings/app_pages/cue.py" line="27" />
+      <source>Cue Settings</source>
+      <translation>Cue Settings</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/midi.ts
+++ b/lisp/i18n/ts/en/midi.ts
@@ -208,14 +208,14 @@
   <context>
     <name>SettingsPageName</name>
     <message>
-      <location filename="../../../plugins/midi/midi_settings.py" line="37" />
-      <source>MIDI settings</source>
-      <translation>MIDI settings</translation>
-    </message>
-    <message>
       <location filename="../../../plugins/midi/midi_cue.py" line="57" />
       <source>MIDI Settings</source>
       <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/midi/midi_settings.py" line="37" />
+      <source>MIDI settings</source>
+      <translation>MIDI settings</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/presets.ts
+++ b/lisp/i18n/ts/en/presets.ts
@@ -17,14 +17,29 @@
   <context>
     <name>Presets</name>
     <message>
+      <location filename="../../../plugins/presets/presets_ui.py" line="355" />
+      <source>Presets</source>
+      <translation>Presets</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/presets/presets.py" line="73" />
+      <source>Apply to cue</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/presets/presets.py" line="75" />
+      <source>Apply to selected cues</source>
+      <translation type="unfinished" />
+    </message>
+    <message>
+      <location filename="../../../plugins/presets/presets.py" line="79" />
+      <source>Save as preset</source>
+      <translation>Save as preset</translation>
+    </message>
+    <message>
       <location filename="../../../plugins/presets/presets_ui.py" line="66" />
       <source>Cannot scan presets</source>
       <translation>Cannot scan presets</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="68" />
-      <source>Presets</source>
-      <translation>Presets</translation>
     </message>
     <message>
       <location filename="../../../plugins/presets/presets_ui.py" line="423" />
@@ -125,21 +140,6 @@
       <location filename="../../../plugins/presets/presets_ui.py" line="312" />
       <source>Cannot create a cue from this preset: {}</source>
       <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="73" />
-      <source>Apply to cue</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="75" />
-      <source>Apply to selected cues</source>
-      <translation type="unfinished" />
-    </message>
-    <message>
-      <location filename="../../../plugins/presets/presets.py" line="79" />
-      <source>Save as preset</source>
-      <translation>Save as preset</translation>
     </message>
   </context>
 </TS>

--- a/lisp/i18n/ts/en/replay_gain.ts
+++ b/lisp/i18n/ts/en/replay_gain.ts
@@ -4,24 +4,9 @@
   <context>
     <name>ReplayGain</name>
     <message>
-      <location filename="../../../plugins/replay_gain/gain_ui.py" line="111" />
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="50" />
       <source>ReplayGain / Normalization</source>
       <translation>ReplayGain / Normalization</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/replay_gain/replay_gain.py" line="55" />
-      <source>Calculate</source>
-      <translation>Calculate</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/replay_gain/replay_gain.py" line="60" />
-      <source>Reset all</source>
-      <translation>Reset all</translation>
-    </message>
-    <message>
-      <location filename="../../../plugins/replay_gain/replay_gain.py" line="66" />
-      <source>Reset selected</source>
-      <translation>Reset selected</translation>
     </message>
     <message>
       <location filename="../../../plugins/replay_gain/gain_ui.py" line="113" />
@@ -47,6 +32,21 @@
       <location filename="../../../plugins/replay_gain/gain_ui.py" line="145" />
       <source>Processing files ...</source>
       <translation>Processing files ...</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="55" />
+      <source>Calculate</source>
+      <translation>Calculate</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="60" />
+      <source>Reset all</source>
+      <translation>Reset all</translation>
+    </message>
+    <message>
+      <location filename="../../../plugins/replay_gain/replay_gain.py" line="66" />
+      <source>Reset selected</source>
+      <translation>Reset selected</translation>
     </message>
   </context>
   <context>

--- a/lisp/plugins/gst_backend/elements/bandpass_filter.py
+++ b/lisp/plugins/gst_backend/elements/bandpass_filter.py
@@ -1,0 +1,64 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2016 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from enum import Enum
+from PyQt5.QtCore import QT_TRANSLATE_NOOP
+
+from lisp.backend.media_element import ElementType, MediaType
+from lisp.plugins.gst_backend.gi_repository import Gst
+from lisp.plugins.gst_backend.gst_element import GstMediaElement
+from lisp.plugins.gst_backend.gst_properties import GstProperty
+
+class BandpassFilter(GstMediaElement):
+    ElementType = ElementType.Plugin
+    MediaType = MediaType.Audio
+    Name = QT_TRANSLATE_NOOP("MediaElementName", "Bandpass filter")
+
+    class Window(Enum):
+        Hamming = 0
+        Blackman = 1
+        Gaussian = 2
+        Cosine = 3
+        Hann = 4
+
+    class WindowMode(Enum):
+        BandPass = 0
+        BandReject = 1
+
+    loFreq = GstProperty("bandpass", "lower-frequency", default=1)
+    hiFreq = GstProperty("bandpass", "upper-frequency", default=20000)
+    mode   = GstProperty("bandpass", "mode", default=WindowMode.BandPass)
+    window = GstProperty("bandpass", "window", default=Window.Hamming)
+    length = GstProperty("bandpass", "length", default=101)
+
+    def __init__(self, pipeline):
+        super().__init__(pipeline)
+
+        self.bandpass = Gst.ElementFactory.make("audiowsincband", None)
+        self.audio_converter = Gst.ElementFactory.make("audioconvert", None)
+
+        self.pipeline.add(self.bandpass)
+        self.pipeline.add(self.audio_converter)
+
+        self.bandpass.link(self.audio_converter)
+
+
+    def sink(self):
+        return self.bandpass
+
+    def src(self):
+        return self.audio_converter

--- a/lisp/plugins/gst_backend/elements/highpass_filter.py
+++ b/lisp/plugins/gst_backend/elements/highpass_filter.py
@@ -1,0 +1,60 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtCore import QT_TRANSLATE_NOOP
+
+from enum import Enum
+
+from lisp.backend.media_element import ElementType, MediaType
+from lisp.plugins.gst_backend.gi_repository import Gst
+from lisp.plugins.gst_backend.gst_element import GstMediaElement
+from lisp.plugins.gst_backend.gst_properties import GstProperty
+
+class HighpassFilter(GstMediaElement):
+    ElementType = ElementType.Plugin
+    MediaType = MediaType.Audio
+    Name = QT_TRANSLATE_NOOP("MediaElementName", "Highpass Filter")
+    
+    class Window(Enum):
+        Hamming = 0
+        Blackman = 1
+        Gaussian = 2
+        Cosine = 3
+        Hann = 4
+
+    cutoff = GstProperty("audiowsinclimit", "cutoff", default=110)
+    length = GstProperty("audiowsinclimit", "length", default=101)
+    mode   = GstProperty("audiowsinclimit", "mode", default=1)
+    window = GstProperty("audiowsinclimit", "window", default=Window.Hamming.value)
+
+    def __init__(self, pipeline):
+        super().__init__(pipeline)
+
+        self.audiowsinclimit = Gst.ElementFactory.make("audiowsinclimit", None)
+        self.audio_converter = Gst.ElementFactory.make("audioconvert", None)
+
+        self.pipeline.add(self.audiowsinclimit)
+        self.pipeline.add(self.audio_converter)
+
+        self.audiowsinclimit.link(self.audio_converter)
+
+
+    def sink(self):
+        return self.audiowsinclimit
+
+    def src(self):
+        return self.audio_converter

--- a/lisp/plugins/gst_backend/elements/lowpass_filter.py
+++ b/lisp/plugins/gst_backend/elements/lowpass_filter.py
@@ -1,0 +1,61 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2024 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtCore import QT_TRANSLATE_NOOP
+
+from enum import Enum
+
+from lisp.backend.media_element import ElementType, MediaType
+from lisp.plugins.gst_backend.gi_repository import Gst
+from lisp.plugins.gst_backend.gst_element import GstMediaElement
+from lisp.plugins.gst_backend.gst_properties import GstProperty
+
+# Implements the `audiowsinclimit` filter
+class LowpassFilter(GstMediaElement):
+    ElementType = ElementType.Plugin
+    MediaType = MediaType.Audio
+    Name = QT_TRANSLATE_NOOP("MediaElementName", "Lowpass Filter")
+    
+    class Window(Enum):
+        Hamming = 0
+        Blackman = 1
+        Gaussian = 2
+        Cosine = 3
+        Hann = 4
+
+    cutoff = GstProperty("audiowsinclimit", "cutoff", default=20000)
+    length = GstProperty("audiowsinclimit", "length", default=101)
+    mode = GstProperty("audiowsinclimit", "mode", default=0)
+    window = GstProperty("audiowsinclimit", "window", default=Window.Hamming.value)
+
+    def __init__(self, pipeline):
+        super().__init__(pipeline)
+
+        self.audiowsinclimit = Gst.ElementFactory.make("audiowsinclimit", None)
+        self.audio_converter = Gst.ElementFactory.make("audioconvert", None)
+
+        self.pipeline.add(self.audiowsinclimit)
+        self.pipeline.add(self.audio_converter)
+
+        self.audiowsinclimit.link(self.audio_converter)
+
+
+    def sink(self):
+        return self.audiowsinclimit
+
+    def src(self):
+        return self.audio_converter

--- a/lisp/plugins/gst_backend/settings/bandpass_filter.py
+++ b/lisp/plugins/gst_backend/settings/bandpass_filter.py
@@ -1,0 +1,155 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFontMetrics
+from PyQt5.QtWidgets import QGroupBox, QGridLayout, QLabel, QSlider, QVBoxLayout, QComboBox
+
+from lisp.plugins.gst_backend.elements.bandpass_filter import BandpassFilter
+from lisp.ui.settings.pages import SettingsPage
+from lisp.ui.ui_utils import translate
+
+
+class BandpassFilterSettings(SettingsPage):
+    ELEMENT = BandpassFilter
+    Name = ELEMENT.Name
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+
+        self.groupBox = QGroupBox(self)
+        self.groupBox.resize(self.size())
+        self.groupBox.setTitle(
+            translate("BandpassFilterSettings", "Bandpass Filter")
+        )
+        self.groupBox.setLayout(QGridLayout())
+        self.groupBox.layout().setVerticalSpacing(0)
+        self.layout().addWidget(self.groupBox)
+
+        self.sliders = {}
+
+        
+         # Low-freq
+        lLabel = QLabel(self.groupBox)
+        lLabel.setMinimumWidth(QFontMetrics(lLabel.font()).width("000"))
+        lLabel.setAlignment(QtCore.Qt.AlignCenter)
+        lLabel.setNum(0)
+        self.groupBox.layout().addWidget(lLabel, 0, 0)
+
+        slider = QSlider(self.groupBox)
+        slider.setRange(0, 20000)
+        slider.setPageStep(1)
+        slider.setValue(0)
+        slider.setOrientation(QtCore.Qt.Horizontal)
+        slider.valueChanged.connect(lLabel.setNum)
+        self.groupBox.layout().addWidget(slider, 1, 0)
+        self.groupBox.layout().setAlignment(slider, QtCore.Qt.AlignVCenter)
+        self.sliders["lofreq"] = slider
+
+        fLabel = QLabel(self.groupBox)
+        fLabel.setStyleSheet("font-size: 8pt;")
+        fLabel.setAlignment(QtCore.Qt.AlignCenter)
+        fLabel.setText(translate("BandpassFilterSettings", "Lower Frequency"))
+        self.groupBox.layout().addWidget(fLabel, 3, 0)
+
+        # High-freq
+        hLabel = QLabel(self.groupBox)
+        hLabel.setMinimumWidth(QFontMetrics(hLabel.font()).width("000"))
+        hLabel.setAlignment(QtCore.Qt.AlignCenter)
+        hLabel.setNum(0)
+        self.groupBox.layout().addWidget(hLabel, 4, 0)
+
+        slider = QSlider(self.groupBox)
+        slider.setRange(0, 20000)
+        slider.setPageStep(1)
+        slider.setValue(20000)
+        slider.setOrientation(QtCore.Qt.Horizontal)
+        slider.valueChanged.connect(hLabel.setNum)
+        self.groupBox.layout().addWidget(slider, 5, 0)
+        self.groupBox.layout().setAlignment(slider, QtCore.Qt.AlignVCenter)
+        self.sliders["hifreq"] = slider
+
+        fLabel = QLabel(self.groupBox)
+        fLabel.setStyleSheet("font-size: 8pt;")
+        fLabel.setAlignment(QtCore.Qt.AlignCenter)
+        fLabel.setText(translate("BandpassFilterSettings", "Upper Frequency"))
+        self.groupBox.layout().addWidget(fLabel, 6, 0)
+
+        # Window mode
+        self.windowComboBox = QComboBox(self.groupBox)
+        self.windowComboBox.addItem(
+            translate("BandpassFilterSettings", "Hamming"), 'hamming'
+        )
+        self.windowComboBox.addItem(
+            translate("BandpassFilterSettings", "Blackman"), 'blackman'
+        )
+        self.windowComboBox.addItem(
+            translate("BandpassFilterSettings", "Gaussian"), 'gaussian'
+        )
+        self.windowComboBox.addItem(
+            translate("BandpassFilterSettings", "Cosine"), 'cosine'
+        )
+        self.windowComboBox.addItem(
+            translate("BandpassFilterSettings", "Hann"), 'hann'
+        )
+
+        self.groupBox.layout().addWidget(self.windowComboBox, 7, 0, 1, 1)
+        
+        wLabel = QLabel(self.groupBox)
+        wLabel.setStyleSheet("font-size: 8pt;")
+        wLabel.setAlignment(QtCore.Qt.AlignCenter)
+        wLabel.setText(translate("BandpassFilterSettings", "Window Mode"))
+        self.groupBox.layout().addWidget(wLabel, 8, 0)
+
+        # Filter mode
+        self.modeComboBox = QComboBox(self.groupBox)
+        self.modeComboBox.addItem(
+            translate("BandpassFilterSettings", "Band-Pass"), 'band-pass'
+        )
+        self.modeComboBox.addItem(
+            translate("BandpassFilterSettings", "Band-Reject"), 'band-reject'
+        )
+
+        self.groupBox.layout().addWidget(self.modeComboBox, 9, 0, 1, 1)
+        
+        mLabel = QLabel(self.groupBox)
+        mLabel.setStyleSheet("font-size: 8pt;")
+        mLabel.setAlignment(QtCore.Qt.AlignCenter)
+        mLabel.setText(translate("BandpassFilterSettings", "Filter Mode"))
+        self.groupBox.layout().addWidget(mLabel, 10, 0)
+
+    def enableCheck(self, enabled):
+        self.setGroupEnabled(self.groupBox, enabled)
+
+    def getSettings(self):
+        if self.isGroupEnabled(self.groupBox):
+            return {
+                'hiFreq': self.sliders['hifreq'].value(),
+                'loFreq': self.sliders['lofreq'].value(),
+                'window': self.windowComboBox.currentData(),
+                'mode': self.modeComboBox.currentData()
+            }
+
+        return {}
+
+    def loadSettings(self, settings):
+        self.sliders['hifreq'].setValue(settings.get('hiFreq', 200000))
+        self.sliders['lofreq'].setValue(settings.get('loFreq', 1))
+

--- a/lisp/plugins/gst_backend/settings/highpass_filter.py
+++ b/lisp/plugins/gst_backend/settings/highpass_filter.py
@@ -1,0 +1,122 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFontMetrics
+from PyQt5.QtWidgets import (
+    QGroupBox,
+    QGridLayout,
+    QLabel,
+    QSlider,
+    QVBoxLayout,
+    QSpinBox,
+    QComboBox
+)
+from lisp.plugins.gst_backend.elements.highpass_filter import HighpassFilter
+from lisp.ui.settings.pages import SettingsPage
+from lisp.ui.ui_utils import translate
+
+
+class HighpassFilterSettings(SettingsPage):
+    ELEMENT = HighpassFilter
+    Name = ELEMENT.Name
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+
+        self.groupBox = QGroupBox(self)
+        self.groupBox.resize(self.size())
+        self.groupBox.setTitle(
+            translate("HighpassFilterSettings", "Highpass Settings")
+        )
+        self.groupBox.setLayout(QGridLayout())
+        self.groupBox.layout().setVerticalSpacing(0)
+        self.layout().addWidget(self.groupBox)
+
+        # High-pass
+        self.freqSpin = QSpinBox(self.groupBox)
+        self.freqSpin.setRange(0, 20000)
+        self.freqSpin.setMaximum(20000)
+        self.freqSpin.setValue(110)
+        self.groupBox.layout().addWidget(self.freqSpin, 0, 0)
+
+
+        slider = QSlider(self.groupBox)
+        slider.setRange(0, 20000)
+        slider.setPageStep(1)
+        slider.setValue(110)
+        slider.setOrientation(QtCore.Qt.Horizontal)
+        slider.valueChanged.connect(self.freqSpin.setValue)
+        self.groupBox.layout().addWidget(slider, 1, 0)
+        self.groupBox.layout().setAlignment(slider, QtCore.Qt.AlignVCenter)
+        self.slider = slider
+        self.freqSpin.valueChanged.connect(self.slider.setValue)
+
+
+        fLabel = QLabel(self.groupBox)
+        fLabel.setStyleSheet("font-size: 8pt;")
+        fLabel.setAlignment(QtCore.Qt.AlignCenter)
+        fLabel.setText(translate("HighpassFilterSettings", "High-pass Frequency"))
+        self.groupBox.layout().addWidget(fLabel, 2, 0)
+
+        self.modeComboBox = QComboBox(self.groupBox)
+        self.modeComboBox.addItem(
+            translate("HighpassFilterSettings", "Hamming"), 'hamming'
+        )
+        self.modeComboBox.addItem(
+            translate("HighpassFilterSettings", "Blackman"), 'blackman'
+        )
+        self.modeComboBox.addItem(
+            translate("HighpassFilterSettings", "Gaussian"), 'gaussian'
+        )
+        self.modeComboBox.addItem(
+            translate("HighpassFilterSettings", "Cosine"), 'cosine'
+        )
+        self.modeComboBox.addItem(
+            translate("HighpassFilterSettings", "Hann"), 'hann'
+        )
+
+        self.groupBox.layout().addWidget(self.modeComboBox, 3, 0, 1, 1)
+        
+        wLabel = QLabel(self.groupBox)
+        wLabel.setStyleSheet("font-size: 8pt;")
+        wLabel.setAlignment(QtCore.Qt.AlignCenter)
+        wLabel.setText(translate("HighpassFilterSettings", "Windowing Mode"))
+        self.groupBox.layout().addWidget(wLabel, 6, 0)
+
+    def enableCheck(self, enabled):
+        self.setGroupEnabled(self.groupBox, enabled)
+
+    def getSettings(self):
+        if self.isGroupEnabled(self.groupBox):
+            return {
+                'cutoff': self.slider.value(),
+                'window': self.modeComboBox.currentData(),
+                'mode': 1
+            }
+
+        return {}
+
+    def loadSettings(self, settings):
+        self.slider.setValue(settings.get('cutoff', 0))
+        self.modeComboBox.setCurrentText(
+            translate("HighpassFilterSettings", str(settings.get('window', 'hamming')).title())
+        )
+

--- a/lisp/plugins/gst_backend/settings/lowpass_filter.py
+++ b/lisp/plugins/gst_backend/settings/lowpass_filter.py
@@ -1,0 +1,121 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2018 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFontMetrics
+from PyQt5.QtWidgets import (
+    QGroupBox,
+    QGridLayout,
+    QLabel,
+    QSlider,
+    QVBoxLayout,
+    QSpinBox,
+    QComboBox
+)
+from lisp.plugins.gst_backend.elements.lowpass_filter import LowpassFilter
+from lisp.ui.settings.pages import SettingsPage
+from lisp.ui.ui_utils import translate
+
+
+class LowpassFilterSettings(SettingsPage):
+    ELEMENT = LowpassFilter
+    Name = ELEMENT.Name
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+
+        self.groupBox = QGroupBox(self)
+        self.groupBox.resize(self.size())
+        self.groupBox.setTitle(
+            translate("LowpassFilterSettings", "Lowpass Settings")
+        )
+        self.groupBox.setLayout(QGridLayout())
+        self.groupBox.layout().setVerticalSpacing(0)
+        self.layout().addWidget(self.groupBox)
+
+        self.freqSpin = QSpinBox(self.groupBox)
+        self.freqSpin.setRange(0, 20000)
+        self.freqSpin.setMaximum(20000)
+        self.freqSpin.setValue(110)
+        self.groupBox.layout().addWidget(self.freqSpin, 0, 0)
+
+
+        slider = QSlider(self.groupBox)
+        slider.setRange(0, 20000)
+        slider.setPageStep(1)
+        slider.setValue(110)
+        slider.setOrientation(QtCore.Qt.Horizontal)
+        slider.valueChanged.connect(self.freqSpin.setValue)
+        self.groupBox.layout().addWidget(slider, 1, 0)
+        self.groupBox.layout().setAlignment(slider, QtCore.Qt.AlignVCenter)
+        self.slider = slider
+        self.freqSpin.valueChanged.connect(self.slider.setValue)
+
+
+        fLabel = QLabel(self.groupBox)
+        fLabel.setStyleSheet("font-size: 8pt;")
+        fLabel.setAlignment(QtCore.Qt.AlignCenter)
+        fLabel.setText(translate("LowpassFilterSettings", "Low-pass Frequency", "Low-pass Frequency"))
+        self.groupBox.layout().addWidget(fLabel, 2, 0)
+
+        self.modeComboBox = QComboBox(self.groupBox)
+        self.modeComboBox.addItem(
+            translate("LowpassFilterSettings", "Hamming"), 'hamming'
+        )
+        self.modeComboBox.addItem(
+            translate("LowpassFilterSettings", "Blackman"), 'blackman'
+        )
+        self.modeComboBox.addItem(
+            translate("LowpassFilterSettings", "Gaussian"), 'gaussian'
+        )
+        self.modeComboBox.addItem(
+            translate("LowpassFilterSettings", "Cosine"), 'cosine'
+        )
+        self.modeComboBox.addItem(
+            translate("LowpassFilterSettings", "Hann"), 'hann'
+        )
+
+        self.groupBox.layout().addWidget(self.modeComboBox, 3, 0, 1, 1)
+        
+        wLabel = QLabel(self.groupBox)
+        wLabel.setStyleSheet("font-size: 8pt;")
+        wLabel.setAlignment(QtCore.Qt.AlignCenter)
+        wLabel.setText(translate("LowpassFilterSettings", "Windowing Mode"))
+        self.groupBox.layout().addWidget(wLabel, 6, 0)
+
+    def enableCheck(self, enabled):
+        self.setGroupEnabled(self.groupBox, enabled)
+
+    def getSettings(self):
+        if self.isGroupEnabled(self.groupBox):
+            return {
+                'cutoff': self.slider.value(),
+                'window': self.modeComboBox.currentData(),
+                'mode': 0
+            }
+
+        return {}
+
+    def loadSettings(self, settings):
+        self.slider.setValue(settings.get('cutoff', 0))
+        self.modeComboBox.setCurrentText(
+            translate("LowpassFilterSettings", str(settings.get('window', 'hamming')).title())
+        )
+


### PR DESCRIPTION
# Description

This PR adds a suite of audio filter plugins to the available audio pipeline plugins. The following new plugins are added:
- Highpass Filter
- Lowpass Filter
- Bandpass Filter

## Highpass Filter

This is a classic highpass filter which implements the `audiowsinclimit` Gstreamer plugin.
The following controls are exposed to the user:

- Cutoff frequency (Hz)
- Window Mode

## Lowpass Filter

This is a classic lowpass filter which implements the `audiowsinclimit` Gstreamer plugin.
The following controls are exposed to the user:

- Cutoff frequency (Hz)
- Window Mode

## Bandpass Filter

This is a variable bandpass/band-reject filter which implements the `audiowsincband` Gstreamer plugin.
The following controls are exposed to the user:

- Lower cutoff frequency
- Upper cutoff frequency
- Filter mode (Bandpass/Band-reject)
- Window Mode