### PR TITLE
Improvement: Prevent application crash on Save Session

### DIFF
--- a/lisp/application.py
+++ b/lisp/application.py
@@ -194,25 +194,36 @@ class Application(metaclass=Singleton):
             "cues": session_cues,
         }
         
-        # Verify session data before writing to file
-        session_json = None
         if self.conf.get("session.minSave", False):
             dump_options = {"separators": (",", ":")}
         else:
             dump_options = {"sort_keys": True, "indent": 4}
+
+        # Serialize the session in a JSON string, and overwrite the active session file
         try:
             session_json = json.dumps(session_dict, **dump_options)
         except TypeError:
             logger.exception(
-            translate(
-                "ApplicationError",
-                '''
-                Error while writing the session file "{}"\n
-                Due to bad data, the session cannot be saved.
-                Please check any recent changes to cue pipelines.
-                '''
-            ).format(session_file)
-        )
+                translate(
+                    "ApplicationError",
+                    """
+                    Error while writing the session file "{}"\n
+                    Due to bad data, the session cannot be saved.
+                    Please check any recent changes to cue pipelines.
+                    """,
+                ).format(session_file)
+            )
+        else:
+            with open(session_file, mode="w", encoding="utf-8") as file:
+                file.write(session_json)
+
+            # Save last session path
+            self.conf.set("session.lastPath", dirname(session_file))
+            self.conf.write()
+
+            # Set the session as saved
+            self.commands_stack.set_saved()
+            self.window.updateWindowTitle()
 
         # Write to a file the json-encoded session
         if session_json:

--- a/lisp/application.py
+++ b/lisp/application.py
@@ -225,19 +225,6 @@ class Application(metaclass=Singleton):
             self.commands_stack.set_saved()
             self.window.updateWindowTitle()
 
-        # Write to a file the json-encoded session
-        if session_json:
-            with open(session_file, mode="w", encoding="utf-8") as file:                
-                file.write(session_json)
-            
-            # Save last session path
-            self.conf.set("session.lastPath", dirname(session_file))
-            self.conf.write()
-
-            # Set the session as saved
-            self.commands_stack.set_saved()
-            self.window.updateWindowTitle()
-
     def __load_from_file(self, session_file):
         """Load a saved session from file"""
         try:


### PR DESCRIPTION
**Abstract**

This PR is meant to address issue #335 - Application crashes on save with bad session data.

**Description**

This PR changes the logic of `__save_to_file()` in `application.py` by first checking to ensure the JSON serialization of session data was successful before opening the file, writing data, changing application title and saving session.

In the event there is data present in the in-memory session which is **not** serializable into JSON (for example, if a plugin `GstProperty` returns a GObject rather than a simple type) a meaningful error message will be displayed to the user.

![lsp-bad-session-data-error-message](https://github.com/user-attachments/assets/4ac53ee8-f966-4db7-8cd7-090caf50afab)
