### PR TITLE
Navigate to previous/next cart page via OSC/MIDI

### DIFF
--- a/lisp/plugins/cart_layout/layout.py
+++ b/lisp/plugins/cart_layout/layout.py
@@ -286,6 +286,16 @@ class CartLayout(CueLayout):
                 if pattern.fullmatch(self._cart_view.tabText(n)):
                     self._cart_view.setTabText(n, text.format(number=n + 1))
 
+    def go_to_page(self, page_number):
+        page_number = max(0, min(page_number, self._cart_view.count()))
+        self._cart_view.setCurrentIndex(page_number)
+
+    def decrement_page(self):
+        self.go_to_page(self._cart_view.currentIndex() - 1)
+
+    def increment_page(self):
+        self.go_to_page(self._cart_view.currentIndex() + 1)
+
     @tabs.get
     def _get_tabs(self):
         return self._cart_view.tabTexts()

--- a/lisp/plugins/controller/common.py
+++ b/lisp/plugins/controller/common.py
@@ -36,6 +36,9 @@ class LayoutAction(Enum):
     StandbyForward = "StandbyForward"
     StandbyBack = "StandbyBack"
 
+    PreviousPage = "PreviousPage"
+    NextPage = "NextPage"
+
 
 LayoutActionsStrings = {
     LayoutAction.Go: QT_TRANSLATE_NOOP("GlobalAction", "Go"),
@@ -59,6 +62,12 @@ LayoutActionsStrings = {
     ),
     LayoutAction.StandbyBack: QT_TRANSLATE_NOOP(
         "GlobalAction", "Move standby back"
+    ),
+    LayoutAction.PreviousPage: QT_TRANSLATE_NOOP(
+        "GlobalAction", "Switch to previous page"
+    ),
+    LayoutAction.NextPage: QT_TRANSLATE_NOOP(
+        "GlobalAction", "Switch to next page"
     ),
 }
 

--- a/lisp/plugins/controller/controller.py
+++ b/lisp/plugins/controller/controller.py
@@ -140,6 +140,12 @@ class Controller(Plugin):
                 self.app.layout.set_standby_index(
                     self.app.layout.standby_index() - 1
                 )
+            elif action is LayoutAction.PreviousPage:
+                if hasattr(self.app.layout, 'decrement_page'):
+                    self.app.layout.decrement_page()
+            elif action is LayoutAction.NextPage:
+                if hasattr(self.app.layout, 'increment_page'):
+                    self.app.layout.increment_page()
             else:
                 self.app.finalize()
 


### PR DESCRIPTION
This PR adds the ability for users to define a keyboard shortcut, or a MIDI or OSC message that, upon receipt, will cause LiSP to bring up the previous or next page in the Cart Layout.

(It's not possible for the message to specify a specific Page to go to, however - that would require a much larger change.)

Refs. #255, #337