### PR TITLE
Adding Pause and Resume actions to all non-media cues

### DIFF
--- a/lisp/plugins/action_cues/collection_cue.py
+++ b/lisp/plugins/action_cues/collection_cue.py
@@ -43,6 +43,14 @@ class CollectionCue(Cue):
     Name = QT_TRANSLATE_NOOP("CueName", "Collection Cue")
     Category = QT_TRANSLATE_NOOP("CueCategory", "Action cues")
 
+    CueActions = (
+        CueAction.Default,
+        CueAction.Start,
+        CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
+    )
+
     targets = Property(default=[])
 
     def __init__(self, *args, **kwargs):

--- a/lisp/plugins/action_cues/command_cue.py
+++ b/lisp/plugins/action_cues/command_cue.py
@@ -40,7 +40,14 @@ class CommandCue(Cue):
 
     Name = QT_TRANSLATE_NOOP("CueName", "Command Cue")
     Category = None
-    CueActions = (CueAction.Default, CueAction.Start, CueAction.Stop)
+    
+    CueActions = (
+        CueAction.Default,
+        CueAction.Start,
+        CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
+    )
 
     command = Property(default="")
     no_output = Property(default=True)

--- a/lisp/plugins/action_cues/index_action_cue.py
+++ b/lisp/plugins/action_cues/index_action_cue.py
@@ -39,6 +39,14 @@ class IndexActionCue(Cue):
     Name = QT_TRANSLATE_NOOP("CueName", "Index Action")
     Category = QT_TRANSLATE_NOOP("CueCategory", "Action cues")
 
+    CueActions = (
+        CueAction.Default,
+        CueAction.Start,
+        CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
+    )
+
     target_index = Property(default=0)
     relative = Property(default=True)
     action = Property(default=CueAction.Stop.value)

--- a/lisp/plugins/action_cues/seek_cue.py
+++ b/lisp/plugins/action_cues/seek_cue.py
@@ -28,7 +28,7 @@ from PyQt5.QtWidgets import (
 
 from lisp.application import Application
 from lisp.core.properties import Property
-from lisp.cues.cue import Cue
+from lisp.cues.cue import Cue, CueAction
 from lisp.cues.media_cue import MediaCue
 from lisp.ui.cuelistdialog import CueSelectDialog
 from lisp.ui.settings.cue_settings import CueSettingsRegistry
@@ -39,6 +39,14 @@ from lisp.ui.ui_utils import translate
 class SeekCue(Cue):
     Name = QT_TRANSLATE_NOOP("CueName", "Seek Cue")
     Category = QT_TRANSLATE_NOOP("CueCategory", "Action cues")
+
+    CueActions = (
+        CueAction.Default,
+        CueAction.Start,
+        CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
+    )
 
     target_id = Property()
     time = Property(default=-1)

--- a/lisp/plugins/action_cues/stop_all.py
+++ b/lisp/plugins/action_cues/stop_all.py
@@ -29,6 +29,14 @@ class StopAll(Cue):
     Name = QT_TRANSLATE_NOOP("CueName", "Stop-All")
     Category = QT_TRANSLATE_NOOP("CueCategory", "Action cues")
 
+    CueActions = (
+        CueAction.Default,
+        CueAction.Start,
+        CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
+    )
+
     action = Property(default=CueAction.Stop.value)
 
     def __init__(self, *args, **kwargs):

--- a/lisp/plugins/action_cues/volume_control.py
+++ b/lisp/plugins/action_cues/volume_control.py
@@ -62,7 +62,9 @@ class VolumeControl(Cue):
         CueAction.Default,
         CueAction.Start,
         CueAction.Stop,
-        CueAction.Interrupt,
+        CueAction.Pause,
+        CueAction.Resume,
+        CueAction.Interrupt
     )
 
     def __init__(self, *args, **kwargs):

--- a/lisp/plugins/midi/midi_cue.py
+++ b/lisp/plugins/midi/midi_cue.py
@@ -21,7 +21,7 @@ from PyQt5.QtCore import QT_TRANSLATE_NOOP
 from PyQt5.QtWidgets import QVBoxLayout
 
 from lisp.core.properties import Property
-from lisp.cues.cue import Cue
+from lisp.cues.cue import Cue, CueAction
 from lisp.plugins import get_plugin
 from lisp.plugins.midi.midi_utils import (
     midi_str_to_dict,
@@ -38,6 +38,14 @@ logger = logging.getLogger(__name__)
 
 class MidiCue(Cue):
     Name = QT_TRANSLATE_NOOP("CueName", "MIDI Cue")
+
+    CueActions = (
+        CueAction.Default,
+        CueAction.Start,
+        CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
+    )
 
     message = Property(default="")
 

--- a/lisp/plugins/osc/osc_cue.py
+++ b/lisp/plugins/osc/osc_cue.py
@@ -67,6 +67,8 @@ class OscCue(Cue):
         CueAction.Default,
         CueAction.Start,
         CueAction.Stop,
+        CueAction.Pause,
+        CueAction.Resume
     )
 
     path = Property(default="")


### PR DESCRIPTION
This change adds Pause and Resume CueActions to all cues.  That way they can pause with the Pause All button along with Media Cues.  This is a bug fix for issue #340.