### PR TITLE
Time formatting

### DIFF
--- a/lisp/core/util.py
+++ b/lisp/core/util.py
@@ -105,19 +105,19 @@ def time_tuple(milliseconds):
     return hours, minutes, seconds, milliseconds
 
 
-def strtime(time, accurate=False, duration=False):
+def strtime(time, accurate=False, showHundredths=False):
     """Return a string from the given milliseconds time.
 
-    - when >= 1h                 -> hh:mm:ss
-    - when < 1h and duration     -> mm:ss:zz
-    - when < 1h and accurate     -> mm:ss:z0
-    - when < 1h and not accurate -> mm:ss:00
+    - when >= 1h                   -> hh:mm:ss
+    - when < 1h and showHundredths -> mm:ss:zz
+    - when < 1h and accurate       -> mm:ss:z0
+    - when < 1h and not accurate   -> mm:ss:00
     """
 
     hours, minutes, seconds, milliseconds = time_tuple(int(time))
     if hours > 0:
         return f"{hours:02}:{minutes:02}:{seconds:02}"
-    elif duration:
+    elif showHundredths:
         return f"{minutes:02}:{seconds:02}.{round(milliseconds / 10):02}"
     elif accurate:
         return f"{minutes:02}:{seconds:02}.{milliseconds // 100}0"

--- a/lisp/core/util.py
+++ b/lisp/core/util.py
@@ -105,17 +105,20 @@ def time_tuple(milliseconds):
     return hours, minutes, seconds, milliseconds
 
 
-def strtime(time, accurate=False):
+def strtime(time, accurate=False, duration=False):
     """Return a string from the given milliseconds time.
 
     - when >= 1h                 -> hh:mm:ss
-    - when < 1h and accurate     -> mm:ss:00
-    - when < 1h and not accurate -> mm:ss:z0
+    - when < 1h and duration     -> mm:ss:zz
+    - when < 1h and accurate     -> mm:ss:z0
+    - when < 1h and not accurate -> mm:ss:00
     """
 
     hours, minutes, seconds, milliseconds = time_tuple(int(time))
     if hours > 0:
         return f"{hours:02}:{minutes:02}:{seconds:02}"
+    elif duration:
+        return f"{minutes:02}:{seconds:02}.{round(milliseconds / 10):02}"
     elif accurate:
         return f"{minutes:02}:{seconds:02}.{milliseconds // 100}0"
     else:

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -199,7 +199,13 @@ class TimeWidget(QProgressBar):
             # Display as disabled if duration < 0
             self.setEnabled(duration > 0)
             self.setTextVisible(True)
-            self.setFormat(strtime(duration, accurate=self.accurateTime, duration=True))
+            self.setFormat(
+                strtime(
+                    duration,
+                    accurate=self.accurateTime,
+                    showHundredths=True
+                )
+            )
             # Avoid settings min and max to 0, or the bar go in busy state
             self.setRange(0 if duration > 0 else -1, int(duration))
         else:

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -199,7 +199,7 @@ class TimeWidget(QProgressBar):
             # Display as disabled if duration < 0
             self.setEnabled(duration > 0)
             self.setTextVisible(True)
-            self.setFormat(strtime(duration, accurate=self.accurateTime))
+            self.setFormat(strtime(duration, accurate=self.accurateTime, duration=True))
             # Avoid settings min and max to 0, or the bar go in busy state
             self.setRange(0 if duration > 0 else -1, int(duration))
         else:

--- a/lisp/ui/settings/cue_pages/cue_general.py
+++ b/lisp/ui/settings/cue_pages/cue_general.py
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5.QtCore import Qt, QT_TRANSLATE_NOOP
+from PyQt5.QtCore import Qt, QTime, QT_TRANSLATE_NOOP
 from PyQt5.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QVBoxLayout,
     QDoubleSpinBox,
+    QTimeEdit,
 )
 
 from lisp.cues.cue import CueAction
@@ -164,9 +165,9 @@ class CueWaitsPage(CueSettingsPage):
         self.preWaitGroup.setLayout(QHBoxLayout())
         self.layout().addWidget(self.preWaitGroup)
 
-        self.preWaitSpin = QDoubleSpinBox(self.preWaitGroup)
-        self.preWaitSpin.setMaximum(3600 * 24)
-        self.preWaitGroup.layout().addWidget(self.preWaitSpin)
+        self.preWaitEdit = QTimeEdit(self.preWaitGroup)
+        self.preWaitEdit.setDisplayFormat("HH:mm:ss.zzz")
+        self.preWaitGroup.layout().addWidget(self.preWaitEdit)
 
         self.preWaitLabel = QLabel(self.preWaitGroup)
         self.preWaitLabel.setAlignment(Qt.AlignCenter)
@@ -177,9 +178,9 @@ class CueWaitsPage(CueSettingsPage):
         self.postWaitGroup.setLayout(QHBoxLayout())
         self.layout().addWidget(self.postWaitGroup)
 
-        self.postWaitSpin = QDoubleSpinBox(self.postWaitGroup)
-        self.postWaitSpin.setMaximum(3600 * 24)
-        self.postWaitGroup.layout().addWidget(self.postWaitSpin)
+        self.postWaitEdit = QTimeEdit(self.postWaitGroup)
+        self.postWaitEdit.setDisplayFormat("HH:mm:ss.zzz")
+        self.postWaitGroup.layout().addWidget(self.postWaitEdit)
 
         self.postWaitLabel = QLabel(self.postWaitGroup)
         self.postWaitLabel.setAlignment(Qt.AlignCenter)
@@ -217,17 +218,21 @@ class CueWaitsPage(CueSettingsPage):
         self.setGroupEnabled(self.nextActionGroup, enabled)
 
     def loadSettings(self, settings):
-        self.preWaitSpin.setValue(settings.get("pre_wait", 0))
-        self.postWaitSpin.setValue(settings.get("post_wait", 0))
+        preWaitMilliseconds = int(round(settings.get("pre_wait", 0) * 1000))
+        self.preWaitEdit.setTime(QTime(0, 0).addMSecs(preWaitMilliseconds))
+        postWaitMilliseconds = int(round(settings.get("post_wait", 0) * 1000))
+        self.postWaitEdit.setTime(QTime(0, 0).addMSecs(postWaitMilliseconds))
         self.nextActionCombo.setCurrentAction(settings.get("next_action", ""))
 
     def getSettings(self):
         settings = {}
 
         if self.isGroupEnabled(self.preWaitGroup):
-            settings["pre_wait"] = self.preWaitSpin.value()
+            preWaitMs = self.preWaitEdit.time().msecsSinceStartOfDay()
+            settings["pre_wait"] = round(preWaitMs / 1000, 3)
         if self.isGroupEnabled(self.postWaitGroup):
-            settings["post_wait"] = self.postWaitSpin.value()
+            postWaitMs = self.postWaitEdit.time().msecsSinceStartOfDay()
+            settings["post_wait"] = round(postWaitMs / 1000, 3)
         if self.isGroupEnabled(self.nextActionGroup):
             settings["next_action"] = self.nextActionCombo.currentData()
 

--- a/lisp/ui/settings/cue_pages/cue_general.py
+++ b/lisp/ui/settings/cue_pages/cue_general.py
@@ -22,6 +22,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QVBoxLayout,
     QDoubleSpinBox,
+    QDateTimeEdit,
     QTimeEdit,
 )
 
@@ -167,6 +168,8 @@ class CueWaitsPage(CueSettingsPage):
 
         self.preWaitEdit = QTimeEdit(self.preWaitGroup)
         self.preWaitEdit.setDisplayFormat("HH:mm:ss.zzz")
+        self.preWaitEdit.setSelectedSection(QDateTimeEdit.SecondSection)
+        self.preWaitEdit.setSelectedSection(QDateTimeEdit.NoSection)
         self.preWaitGroup.layout().addWidget(self.preWaitEdit)
 
         self.preWaitLabel = QLabel(self.preWaitGroup)
@@ -180,6 +183,8 @@ class CueWaitsPage(CueSettingsPage):
 
         self.postWaitEdit = QTimeEdit(self.postWaitGroup)
         self.postWaitEdit.setDisplayFormat("HH:mm:ss.zzz")
+        self.postWaitEdit.setSelectedSection(QDateTimeEdit.SecondSection)
+        self.postWaitEdit.setSelectedSection(QDateTimeEdit.NoSection)
         self.postWaitGroup.layout().addWidget(self.postWaitEdit)
 
         self.postWaitLabel = QLabel(self.postWaitGroup)

--- a/lisp/ui/settings/cue_pages/media_cue.py
+++ b/lisp/ui/settings/cue_pages/media_cue.py
@@ -42,7 +42,7 @@ class MediaCueSettings(SettingsPage):
         self.layout().addWidget(self.startGroup)
 
         self.startEdit = QTimeEdit(self.startGroup)
-        self.startEdit.setDisplayFormat("HH.mm.ss.zzz")
+        self.startEdit.setDisplayFormat("HH:mm:ss.zzz")
         self.startGroup.layout().addWidget(self.startEdit)
 
         self.startLabel = QLabel(self.startGroup)
@@ -55,7 +55,7 @@ class MediaCueSettings(SettingsPage):
         self.layout().addWidget(self.stopGroup)
 
         self.stopEdit = QTimeEdit(self.stopGroup)
-        self.stopEdit.setDisplayFormat("HH.mm.ss.zzz")
+        self.stopEdit.setDisplayFormat("HH:mm:ss.zzz")
         self.stopGroup.layout().addWidget(self.stopEdit)
 
         self.stopLabel = QLabel(self.stopGroup)

--- a/lisp/ui/settings/cue_pages/media_cue.py
+++ b/lisp/ui/settings/cue_pages/media_cue.py
@@ -19,6 +19,7 @@ from PyQt5.QtCore import QTime, Qt, QT_TRANSLATE_NOOP
 from PyQt5.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
+    QDateTimeEdit,
     QTimeEdit,
     QLabel,
     QSpinBox,
@@ -43,6 +44,8 @@ class MediaCueSettings(SettingsPage):
 
         self.startEdit = QTimeEdit(self.startGroup)
         self.startEdit.setDisplayFormat("HH:mm:ss.zzz")
+        self.startEdit.setSelectedSection(QDateTimeEdit.SecondSection)
+        self.startEdit.setSelectedSection(QDateTimeEdit.NoSection)
         self.startGroup.layout().addWidget(self.startEdit)
 
         self.startLabel = QLabel(self.startGroup)
@@ -56,6 +59,8 @@ class MediaCueSettings(SettingsPage):
 
         self.stopEdit = QTimeEdit(self.stopGroup)
         self.stopEdit.setDisplayFormat("HH:mm:ss.zzz")
+        self.stopEdit.setSelectedSection(QDateTimeEdit.SecondSection)
+        self.stopEdit.setSelectedSection(QDateTimeEdit.NoSection)
         self.stopGroup.layout().addWidget(self.stopEdit)
 
         self.stopLabel = QLabel(self.stopGroup)


### PR DESCRIPTION
Here are the changes talked about in discussion #345 

- Durations are now displayed with accurate hundredths of seconds in List Layout
- Pre/post wait times in the cue settings are editable in HH:mm:ss.zzz format
- Media start/stop times are in HH:mm:ss.zzz format
- Spin buttons for pre/post wait and start/stop times manipulate seconds by default

I have spent some time reviewing and testing.  Let me know if you see any problems.