### PR TITLE
Pre/Post Wait Countdown (Issue #86)

### DIFF
--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -274,6 +274,11 @@ class PreWaitWidget(TimeWidget):
         self.waitTime = CueWaitTime(self.cue, mode=CueWaitTime.Mode.Pre)
         self.waitTime.notify.connect(self._updateTime, Connection.QtQueued)
 
+    def _updateTime(self, time):
+        self.setValue(time)
+        timeRemaining = self.cue.pre_wait * 1000 - time
+        self.setFormat(strtime(timeRemaining, accurate=1))
+
     def _updateDuration(self, duration):
         # The wait time is in seconds, we need milliseconds
         super()._updateDuration(duration * 1000)
@@ -296,6 +301,17 @@ class PostWaitWidget(TimeWidget):
         self.cueTime = CueTime(self.cue)
 
         self._nextActionChanged(self.cue.next_action)
+
+    def _updateTime(self, time):
+        self.setValue(time)
+        if (
+            self.cue.next_action == CueNextAction.TriggerAfterWait
+            or self.cue.next_action == CueNextAction.SelectAfterWait
+        ):
+        	timeRemaining = self.cue.post_wait * 1000 - time
+        else:
+            timeRemaining = self.cue.duration - time
+        self.setFormat(strtime(timeRemaining, accurate=1))
 
     def _updateDuration(self, duration):
         if (

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -308,7 +308,7 @@ class PostWaitWidget(TimeWidget):
             self.cue.next_action == CueNextAction.TriggerAfterWait
             or self.cue.next_action == CueNextAction.SelectAfterWait
         ):
-        	timeRemaining = self.cue.post_wait * 1000 - time
+            timeRemaining = self.cue.post_wait * 1000 - time
         else:
             timeRemaining = self.cue.duration - time
         self.setFormat(strtime(timeRemaining, accurate=1))

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -187,7 +187,7 @@ class TimeWidget(QProgressBar):
         self.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
 
         self.cue = item.cue
-        self.widgetDuration = 0
+        self.duration = 0
         self.showZeroDuration = False
 
     def _updateTime(self, time):
@@ -195,7 +195,8 @@ class TimeWidget(QProgressBar):
         self.setFormat(strtime(time, accurate=1))
 
     def _updateDuration(self, duration):
-        self.widgetDuration = duration
+        self.duration = duration
+
         if duration > 0 or self.showZeroDuration:
             # Display as disabled if duration < 0
             self.setEnabled(duration > 0)
@@ -278,8 +279,7 @@ class PreWaitWidget(TimeWidget):
 
     def _updateTime(self, time):
         self.setValue(time)
-        timeRemaining = self.widgetDuration - time
-        self.setFormat(strtime(timeRemaining, accurate=1))
+        self.setFormat(strtime(self.duration - time, accurate=1))
 
     def _updateDuration(self, duration):
         # The wait time is in seconds, we need milliseconds
@@ -306,8 +306,7 @@ class PostWaitWidget(TimeWidget):
 
     def _updateTime(self, time):
         self.setValue(time)
-        timeRemaining = self.widgetDuration - time
-        self.setFormat(strtime(timeRemaining, accurate=1))
+        self.setFormat(strtime(self.duration - time, accurate=1))
 
     def _updateDuration(self, duration):
         if (

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -187,6 +187,7 @@ class TimeWidget(QProgressBar):
         self.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
 
         self.cue = item.cue
+        self.widgetDuration = 0
         self.showZeroDuration = False
 
     def _updateTime(self, time):
@@ -194,6 +195,7 @@ class TimeWidget(QProgressBar):
         self.setFormat(strtime(time, accurate=1))
 
     def _updateDuration(self, duration):
+        self.widgetDuration = duration
         if duration > 0 or self.showZeroDuration:
             # Display as disabled if duration < 0
             self.setEnabled(duration > 0)
@@ -276,7 +278,7 @@ class PreWaitWidget(TimeWidget):
 
     def _updateTime(self, time):
         self.setValue(time)
-        timeRemaining = self.cue.pre_wait * 1000 - time
+        timeRemaining = self.widgetDuration - time
         self.setFormat(strtime(timeRemaining, accurate=1))
 
     def _updateDuration(self, duration):
@@ -304,13 +306,7 @@ class PostWaitWidget(TimeWidget):
 
     def _updateTime(self, time):
         self.setValue(time)
-        if (
-            self.cue.next_action == CueNextAction.TriggerAfterWait
-            or self.cue.next_action == CueNextAction.SelectAfterWait
-        ):
-            timeRemaining = self.cue.post_wait * 1000 - time
-        else:
-            timeRemaining = self.cue.duration - time
+        timeRemaining = self.widgetDuration - time
         self.setFormat(strtime(timeRemaining, accurate=1))
 
     def _updateDuration(self, duration):


### PR DESCRIPTION
This is a draft to implement the feature requested in Issue #86  After looking at it, I realize there is a much cleaner implementation, so I will update the pull request soon.

The primary thing I want to ask about @FrancescoCeruti is the duration of Media Cues when there is start/stop time specified.  The documentation mentions that duration does not account for start/stop.  Is that intentional, or just because it was not implemented?  The reason I ask is because it's a little strange to count down to a time greater than zero.  If it simply wasn't implemented, I will also take a stab at accounting for start/stop in the duration.  I think it's mostly straight forward (except for seeking to positions outside the start/stop).