### PR TITLE
Account for start/stop time in Media Cue duration

### DIFF
--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -53,6 +53,8 @@ class MediaCue(Cue):
         super().__init__(app, id=id)
         self.media = media
         self.media.changed("duration").connect(self._duration_change)
+        self.media.changed("start_time").connect(self._duration_change)
+        self.media.changed("stop_time").connect(self._duration_change)
         self.media.elements_changed.connect(self.__elements_changed)
         self.media.error.connect(self._on_error)
         self.media.eos.connect(self._on_eos)
@@ -212,7 +214,7 @@ class MediaCue(Cue):
         return ended
 
     def current_time(self):
-        return self.media.current_time()
+        return self.media.current_time() - self.media.start_time
 
     def is_fading_in(self):
         return self.__in_fadein
@@ -221,7 +223,10 @@ class MediaCue(Cue):
         return self.__in_fadeout
 
     def _duration_change(self, value):
-        self.duration = value
+        if self.media.stop_time > 0:
+            self.duration = self.media.stop_time - self.media.start_time
+        else:
+            self.duration = self.media.duration - self.media.start_time
 
     def _on_eos(self):
         with self._st_lock:

--- a/lisp/plugins/action_cues/seek_cue.py
+++ b/lisp/plugins/action_cues/seek_cue.py
@@ -119,8 +119,12 @@ class SeekCueSettings(SettingsPage):
 
             if cue is not None:
                 self.targetCueId = cue.id
+                if cue.media.stop_time > 0:
+                    maximumTime = cue.media.stop_time
+                else:
+                    maximumTime = cue.media.duration
                 self.seekEdit.setMaximumTime(
-                    QTime.fromMSecsSinceStartOfDay(cue.media.duration)
+                    QTime.fromMSecsSinceStartOfDay(maximumTime)
                 )
                 self.cueLabel.setText(cue.name)
 

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -274,6 +274,11 @@ class PreWaitWidget(TimeWidget):
         self.waitTime = CueWaitTime(self.cue, mode=CueWaitTime.Mode.Pre)
         self.waitTime.notify.connect(self._updateTime, Connection.QtQueued)
 
+    def _updateTime(self, time):
+        self.setValue(time)
+        timeRemaining = self.cue.pre_wait * 1000 - time
+        self.setFormat(strtime(timeRemaining, accurate=1))
+
     def _updateDuration(self, duration):
         # The wait time is in seconds, we need milliseconds
         super()._updateDuration(duration * 1000)
@@ -296,6 +301,17 @@ class PostWaitWidget(TimeWidget):
         self.cueTime = CueTime(self.cue)
 
         self._nextActionChanged(self.cue.next_action)
+
+    def _updateTime(self, time):
+        self.setValue(time)
+        if (
+            self.cue.next_action == CueNextAction.TriggerAfterWait
+            or self.cue.next_action == CueNextAction.SelectAfterWait
+        ):
+        	timeRemaining = self.cue.post_wait * 1000 - time
+        else:
+            timeRemaining = self.cue.duration - time
+        self.setFormat(strtime(timeRemaining, accurate=1))
 
     def _updateDuration(self, duration):
         if (

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -308,7 +308,7 @@ class PostWaitWidget(TimeWidget):
             self.cue.next_action == CueNextAction.TriggerAfterWait
             or self.cue.next_action == CueNextAction.SelectAfterWait
         ):
-        	timeRemaining = self.cue.post_wait * 1000 - time
+            timeRemaining = self.cue.post_wait * 1000 - time
         else:
             timeRemaining = self.cue.duration - time
         self.setFormat(strtime(timeRemaining, accurate=1))

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -191,6 +191,7 @@ class TimeWidget(QProgressBar):
         self.showZeroDuration = False
 
     def _updateTime(self, time):
+        time = 0 if time < 0 else time
         self.setValue(time)
         self.setFormat(strtime(time, accurate=1))
 

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -187,6 +187,7 @@ class TimeWidget(QProgressBar):
         self.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
 
         self.cue = item.cue
+        self.widgetDuration = 0
         self.showZeroDuration = False
 
     def _updateTime(self, time):
@@ -194,6 +195,7 @@ class TimeWidget(QProgressBar):
         self.setFormat(strtime(time, accurate=1))
 
     def _updateDuration(self, duration):
+        self.widgetDuration = duration
         if duration > 0 or self.showZeroDuration:
             # Display as disabled if duration < 0
             self.setEnabled(duration > 0)
@@ -276,7 +278,7 @@ class PreWaitWidget(TimeWidget):
 
     def _updateTime(self, time):
         self.setValue(time)
-        timeRemaining = self.cue.pre_wait * 1000 - time
+        timeRemaining = self.widgetDuration - time
         self.setFormat(strtime(timeRemaining, accurate=1))
 
     def _updateDuration(self, duration):
@@ -304,13 +306,7 @@ class PostWaitWidget(TimeWidget):
 
     def _updateTime(self, time):
         self.setValue(time)
-        if (
-            self.cue.next_action == CueNextAction.TriggerAfterWait
-            or self.cue.next_action == CueNextAction.SelectAfterWait
-        ):
-            timeRemaining = self.cue.post_wait * 1000 - time
-        else:
-            timeRemaining = self.cue.duration - time
+        timeRemaining = self.widgetDuration - time
         self.setFormat(strtime(timeRemaining, accurate=1))
 
     def _updateDuration(self, duration):

--- a/lisp/plugins/list_layout/playing_widgets.py
+++ b/lisp/plugins/list_layout/playing_widgets.py
@@ -203,7 +203,7 @@ class RunningMediaCueWidget(RunningCueWidget):
         else:
             self.seekSlider = QClickSlider(self.gridLayoutWidget)
             self.seekSlider.setOrientation(Qt.Horizontal)
-            self.seekSlider.setRange(0, cue.duration)
+            self.seekSlider.setRange(0, cue.media.duration)
 
         self.seekSlider.setFocusPolicy(Qt.NoFocus)
         self.seekSlider.sliderMoved.connect(self._seek)
@@ -258,4 +258,4 @@ class RunningMediaCueWidget(RunningCueWidget):
 
     def _update_timers(self, time):
         super()._update_timers(time)
-        self.seekSlider.setValue(time)
+        self.seekSlider.setValue(time + self.cue.media.start_time)


### PR DESCRIPTION
This pull request adjusts the Media Cue duration based on start and stop time.  This is the followup to pull request #350  I merged in #350 here for testing with the countdown changes.  If you want this pull request before 350, let me know and I will isolate these changes.

I played around with the behavior until I got it pretty much how I think it should be.  Here are some things to note:  in the existing master and develop branches, you can currently seek to (manually or with a Seek Cue) a position before the start time, but you cannot seek to a position after the stop time.  I have not changed that behavior, but if you seek before the start time now, the Action column will show 00:00.00 until it reaches the start time.  Also, I restricted the Seek Cue settings to no longer allow times after the stop time.  Let me know if you think it should behave differently.