### PR TITLE
Accounting for start and stop times in Media Cue duration

### DIFF
--- a/docs/user/cues/media_cues.md
+++ b/docs/user/cues/media_cues.md
@@ -37,8 +37,7 @@ provides fine-grained control on the multimedia source, output and applied effec
 * **Stop time:** End position of the media
 * **Loop:** Number of repetitions after first play (-1 is infinite)
 
-Start/End time allow you to trim the media file without modifications, keep in mind that the UI will keep showing the
-original file duration independently of these options.
+Start/End time allow you to trim the media file without modifications. The displayed duration will be adjusted accordingly.
 
 Loops allow to replay the same media multiple times, they _should_ be seamless if the media content is seamless 
 and depending on the media format, `.wav` are usually a safe option.<br>

--- a/lisp/cues/media_cue.py
+++ b/lisp/cues/media_cue.py
@@ -53,6 +53,8 @@ class MediaCue(Cue):
         super().__init__(app, id=id)
         self.media = media
         self.media.changed("duration").connect(self._duration_change)
+        self.media.changed("start_time").connect(self._duration_change)
+        self.media.changed("stop_time").connect(self._duration_change)
         self.media.elements_changed.connect(self.__elements_changed)
         self.media.error.connect(self._on_error)
         self.media.eos.connect(self._on_eos)
@@ -212,7 +214,7 @@ class MediaCue(Cue):
         return ended
 
     def current_time(self):
-        return self.media.current_time()
+        return self.media.current_time() - self.media.start_time
 
     def is_fading_in(self):
         return self.__in_fadein
@@ -221,7 +223,10 @@ class MediaCue(Cue):
         return self.__in_fadeout
 
     def _duration_change(self, value):
-        self.duration = value
+        if self.media.stop_time > 0:
+            self.duration = self.media.stop_time - self.media.start_time
+        else:
+            self.duration = self.media.duration - self.media.start_time
 
     def _on_eos(self):
         with self._st_lock:

--- a/lisp/plugins/action_cues/seek_cue.py
+++ b/lisp/plugins/action_cues/seek_cue.py
@@ -113,19 +113,20 @@ class SeekCueSettings(SettingsPage):
         self.seekGroup.setTitle(translate("SeekCue", "Seek"))
         self.seekLabel.setText(translate("SeekCue", "Time to reach"))
 
+    def getMaximumSeekTime(self, cue):
+        if cue.media.stop_time > 0:
+            maximumTime = cue.media.stop_time
+        else:
+            maximumTime = cue.media.duration
+        return QTime.fromMSecsSinceStartOfDay(maximumTime)
+
     def select_cue(self):
         if self.cueDialog.exec() == self.cueDialog.Accepted:
             cue = self.cueDialog.selected_cue()
 
             if cue is not None:
                 self.targetCueId = cue.id
-                if cue.media.stop_time > 0:
-                    maximumTime = cue.media.stop_time
-                else:
-                    maximumTime = cue.media.duration
-                self.seekEdit.setMaximumTime(
-                    QTime.fromMSecsSinceStartOfDay(maximumTime)
-                )
+                self.seekEdit.setMaximumTime(self.getMaximumSeekTime(cue))
                 self.cueLabel.setText(cue.name)
 
     def enableCheck(self, enabled):
@@ -147,13 +148,7 @@ class SeekCueSettings(SettingsPage):
             cue = Application().cue_model.get(settings.get("target_id"))
             if cue is not None:
                 self.targetCueId = settings["target_id"]
-                if cue.media.stop_time > 0:
-                    maximumTime = cue.media.stop_time
-                else:
-                    maximumTime = cue.media.duration
-                self.seekEdit.setMaximumTime(
-                    QTime.fromMSecsSinceStartOfDay(maximumTime)
-                )
+                self.seekEdit.setMaximumTime(self.getMaximumSeekTime(cue))
                 self.cueLabel.setText(cue.name)
 
             self.seekEdit.setTime(

--- a/lisp/plugins/action_cues/seek_cue.py
+++ b/lisp/plugins/action_cues/seek_cue.py
@@ -119,8 +119,12 @@ class SeekCueSettings(SettingsPage):
 
             if cue is not None:
                 self.targetCueId = cue.id
+                if cue.media.stop_time > 0:
+                    maximumTime = cue.media.stop_time
+                else:
+                    maximumTime = cue.media.duration
                 self.seekEdit.setMaximumTime(
-                    QTime.fromMSecsSinceStartOfDay(cue.media.duration)
+                    QTime.fromMSecsSinceStartOfDay(maximumTime)
                 )
                 self.cueLabel.setText(cue.name)
 
@@ -143,8 +147,12 @@ class SeekCueSettings(SettingsPage):
             cue = Application().cue_model.get(settings.get("target_id"))
             if cue is not None:
                 self.targetCueId = settings["target_id"]
+                if cue.media.stop_time > 0:
+                    maximumTime = cue.media.stop_time
+                else:
+                    maximumTime = cue.media.duration
                 self.seekEdit.setMaximumTime(
-                    QTime.fromMSecsSinceStartOfDay(cue.media.duration)
+                    QTime.fromMSecsSinceStartOfDay(maximumTime)
                 )
                 self.cueLabel.setText(cue.name)
 

--- a/lisp/plugins/list_layout/list_widgets.py
+++ b/lisp/plugins/list_layout/list_widgets.py
@@ -190,6 +190,7 @@ class TimeWidget(QProgressBar):
         self.showZeroDuration = False
 
     def _updateTime(self, time):
+        time = max(0, time)
         self.setValue(time)
         self.setFormat(strtime(time, accurate=1))
 

--- a/lisp/plugins/list_layout/playing_widgets.py
+++ b/lisp/plugins/list_layout/playing_widgets.py
@@ -203,7 +203,7 @@ class RunningMediaCueWidget(RunningCueWidget):
         else:
             self.seekSlider = QClickSlider(self.gridLayoutWidget)
             self.seekSlider.setOrientation(Qt.Horizontal)
-            self.seekSlider.setRange(0, cue.duration)
+            self.seekSlider.setRange(0, cue.media.duration)
 
         self.seekSlider.setFocusPolicy(Qt.NoFocus)
         self.seekSlider.sliderMoved.connect(self._seek)
@@ -258,4 +258,4 @@ class RunningMediaCueWidget(RunningCueWidget):
 
     def _update_timers(self, time):
         super()._update_timers(time)
-        self.seekSlider.setValue(time)
+        self.seekSlider.setValue(time + self.cue.media.start_time)


### PR DESCRIPTION
This pull request adjusts the Media Cue duration based on start and stop time. This is the followup I discussed in pull request #350 

I played around with the behavior until I got it pretty much how I think it should be. Here are some things to note: in the existing master and develop branches, you can currently seek to (manually or with a Seek Cue) a position before the start time, but you cannot seek to a position after the stop time. I have not changed that behavior, but if you seek before the start time now, the Action column will show 00:00.00 until it reaches the start time. Also, I restricted the Seek Cue settings to no longer allow times after the stop time. Let me know if you think any of this should behave differently.
