### PR TITLE
#362 Add current system theme and Support others system theme

### DIFF
--- a/lisp/ui/settings/app_pages/general.py
+++ b/lisp/ui/settings/app_pages/general.py
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import (
 from lisp.layout import get_layouts
 from lisp.ui.icons import icon_themes_names
 from lisp.ui.settings.pages import SettingsPage
-from lisp.ui.themes import themes_names
+from lisp.ui.themes import themes_names, get_theme_text
 from lisp.ui.ui_utils import translate
 from lisp.ui.widgets import LocaleComboBox
 
@@ -75,7 +75,8 @@ class AppGeneral(SettingsPage):
         self.themeLabel = QLabel(self.themeGroup)
         self.themeGroup.layout().addWidget(self.themeLabel, 0, 0)
         self.themeCombo = QComboBox(self.themeGroup)
-        self.themeCombo.addItems(themes_names())
+        for value, text in themes_names().items():
+            self.themeCombo.addItem(text, value)
         self.themeGroup.layout().addWidget(self.themeCombo, 0, 1)
 
         self.iconsLabel = QLabel(self.themeGroup)
@@ -125,7 +126,7 @@ class AppGeneral(SettingsPage):
     def getSettings(self):
         settings = {
             "theme": {
-                "theme": self.themeCombo.currentText(),
+                "theme": self.themeCombo.currentData(),
                 "icons": self.iconsCombo.currentText(),
             },
             "locale": self.localeCombo.currentLocale(),
@@ -148,6 +149,6 @@ class AppGeneral(SettingsPage):
                 self.layoutCombo.findData(layout_name)
             )
 
-        self.themeCombo.setCurrentText(settings["theme"]["theme"])
+        self.themeCombo.setCurrentText(get_theme_text(settings["theme"]["theme"]))
         self.iconsCombo.setCurrentText(settings["theme"]["icons"])
         self.localeCombo.setCurrentLocale(settings["locale"])

--- a/lisp/ui/themes/__init__.py
+++ b/lisp/ui/themes/__init__.py
@@ -1,21 +1,33 @@
 from os import path
 
 from lisp.core.loading import load_classes
+from PyQt5.QtWidgets import QStyleFactory
+from .system import System
 
 _THEMES = {}
-
+_THEME_NAMES = {}
+_THEME_DEFAULT = ''
 
 def load_themes():
     if not _THEMES:
+        _THEMES[''] = System('')
+        _THEME_NAMES[''] = 'System'
         for name, theme in load_classes(__package__, path.dirname(__file__)):
-            _THEMES[name] = theme()
-
+            if name != 'System':
+                _THEMES[name] = theme()
+                _THEME_NAMES[name] = name + ' (Lisp)'
+        for name in QStyleFactory.keys():
+            _THEMES['system.' + name] = System(name)
+            _THEME_NAMES['system.' + name] = name + ' (Qt)'
 
 def themes_names():
     load_themes()
-    return list(_THEMES.keys())
+    return _THEME_NAMES
 
+def get_theme_text(theme_name):
+    load_themes()
+    return _THEME_NAMES.get(theme_name, _THEME_NAMES[_THEME_DEFAULT])
 
 def get_theme(theme_name):
     load_themes()
-    return _THEMES[theme_name]
+    return _THEMES.get(theme_name, _THEMES[_THEME_DEFAULT])

--- a/lisp/ui/themes/system/__init__.py
+++ b/lisp/ui/themes/system/__init__.py
@@ -1,0 +1,1 @@
+from .system import System

--- a/lisp/ui/themes/system/system.py
+++ b/lisp/ui/themes/system/system.py
@@ -1,0 +1,26 @@
+# This file is part of Linux Show Player
+#
+# Copyright 2016 Francesco Ceruti <ceppofrancy@gmail.com>
+#
+# Linux Show Player is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Linux Show Player is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Linux Show Player.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5.QtWidgets import QStyleFactory
+
+class System:
+
+    def __init__(self, name):
+        self._name = name
+
+    def apply(self, qt_app):
+        qt_app.setStyle(QStyleFactory.create(self._name))


### PR DESCRIPTION
New theme combo box :
* In standalone python (Ubuntu 24.04, Gnome)
  ![image](https://github.com/user-attachments/assets/a45dcb6f-cc41-4a1e-bf40-0d85f2e30096)
* In flatpak package
  ![image](https://github.com/user-attachments/assets/8adefc0d-0d02-47b6-805b-af0051ca9429)


I have add Current sytem theme as user can chose him self. And list all theme installed on system.

