### PR TITLE
Session file converter

### DIFF
--- a/lisp/application.py
+++ b/lisp/application.py
@@ -28,6 +28,7 @@ from lisp.core.session import Session
 from lisp.core.signal import Signal
 from lisp.core.singleton import Singleton
 from lisp.core.util import filter_live_properties
+from lisp.core.version_manager import VersionManager
 from lisp.cues.cue import Cue
 from lisp.cues.cue_factory import CueFactory
 from lisp.cues.cue_model import CueModel
@@ -230,6 +231,10 @@ class Application(metaclass=Singleton):
         try:
             with open(session_file, mode="r", encoding="utf-8") as file:
                 session_dict = json.load(file)
+            
+            # Update session to current version if needed
+            manager = VersionManager(session_dict)
+            session_dict = manager.update_to_latest()
 
             # New session
             self.__new_session(

--- a/lisp/core/version_manager.py
+++ b/lisp/core/version_manager.py
@@ -1,0 +1,45 @@
+import copy
+import json
+from typing import Dict, Any
+
+
+class VersionManager:
+    def __init__(self, data: Dict[str, Any]):
+        self.data = data
+    
+    def update_to_latest(self):
+        if "meta" not in self.data:
+            return self._convert_from_0_5()
+        return self.data
+
+    def _convert_from_0_5(self):
+        self._transform_layout()
+        self._transform_cues()
+        return self.data
+
+    def _transform_layout(self):
+        layout = self.data.pop("application", {}).get("layout", "")
+        self.data["session"] = {}
+        self.data["session"]["layout_type"] = layout.replace(" ", "")
+
+    def _transform_cues(self):
+        for cue in self.data["cues"]:
+            if cue["_type_"] == "MediaCue":
+                cue["_type_"] = "GstMediaCue"
+            if "_media_" in cue:
+                cue["media"] = cue.pop("_media_")
+            if "next_action" in cue:
+                cue["next_action"] = (
+                    cue.get("next_action", "")
+                    .replace("AutoNext", "TriggerAfterWait")
+                    .replace("AutoFollow", "TriggerAfterEnd")
+                )
+            self._transform_controller(cue)
+
+    def _transform_controller(self, cue: dict):
+        cue["controller"].setdefault("midi", [])
+        cue["controller"].setdefault("osc", [])
+        midi_entries = cue["controller"]["midi"]
+        for entry in midi_entries:
+            s = entry[0].strip().split()
+            entry[0] = f"{s[0]} channel={s[1]} note={s[2]} velocity=0 time=0"


### PR DESCRIPTION
Here is a converter to automatically detect and upgrade the session file from version 0.5 to the current version.  I took a minimalist approach by only making the necessary changes to make the session open and usable without errors.  I did my best to craft test sessions in 0.5 and load them in 0.6.5.  Most likely there are edge cases that got missed, so it would be nice for others to test with real-world sessions.