### PR TITLE
Replace deprecated appdirs dependency with platformdirs

### DIFF
--- a/lisp/__init__.py
+++ b/lisp/__init__.py
@@ -18,7 +18,7 @@
 import os
 from os import path
 
-from appdirs import AppDirs
+from platformdirs import PlatformDirs
 
 __author__ = "Francesco Ceruti"
 __email__ = "ceppofrancy@gmail.com"
@@ -28,7 +28,7 @@ __version_info__ = (0, 6, 5)
 __version__ = ".".join(map(str, __version_info__))
 
 # The version passed follows <major>.<minor>
-app_dirs = AppDirs(
+app_dirs = PlatformDirs(
     "LinuxShowPlayer", version="{}.{}".format(*__version_info__[0:2])
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">= 3.10, < 4.0"
-appdirs = "^1.4.1"
+platformdirs = ">= 2.0.0"
 falcon = "^4.0.1"
 jack-client = "^0.5"
 mido = "^1.3.3"

--- a/scripts/flatpak/python-modules.json
+++ b/scripts/flatpak/python-modules.json
@@ -2,7 +2,7 @@
     "name": "python-modules",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} appdirs falcon jack-client mido python-osc requests sortedcontainers humanize qdigitalmeter"
+        "pip3 install --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} falcon jack-client mido platformdirs python-osc requests sortedcontainers humanize qdigitalmeter"
     ],
     "sources": [
         {
@@ -27,8 +27,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl",
-            "sha256": "a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            "url": "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl",
+            "sha256": "d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31"
         },
         {
             "type": "file",


### PR DESCRIPTION
As of 2023-02-10, the python package `appdirs` has been marked "officially deprecated" by its maintainers, and they recommend using the fork `platformdirs` instead.

See also:

* Discussion about `appdirs`' maintenance status, and deprecation notice:
  - https://github.com/ActiveState/appdirs/issues/79
  - https://github.com/ActiveState/appdirs/commit/8734277956c1df3b85385e6b308e954910533884

* Replacement recommended by `appdirs`' former maintainers:
  - https://pypi.org/project/platformdirs/
  - https://github.com/tox-dev/platformdirs

* Availability on various repos:
  - https://repology.org/project/python:appdirs
  - https://repology.org/project/appdirs (debian-based repos)
  - https://repology.org/project/python:platformdirs
  - https://repology.org/project/platformdirs (debian-based repos)