### PR TITLE
fix: set Wayland desktop file name

### DIFF
--- a/lisp/main.py
+++ b/lisp/main.py
@@ -108,6 +108,7 @@ def main():
     # Create the QApplication
     qt_app = QApplication(sys.argv)
     qt_app.setApplicationName("Linux Show Player")
+    qt_app.setDesktopFileName("linuxshowplayer")
     qt_app.setQuitOnLastWindowClosed(True)
 
     # Get/Set the locale


### PR DESCRIPTION
AI-generated contribution. I am the human operator responsible for follow-up with maintainers. Please feel free to close this PR or request any changes.

Addresses #378 with the minimal stable app ID setup.

Qt derives the Wayland app_id from the desktop file name when it is set. Linux Show Player already ships `dist/linuxshowplayer.desktop`, so set the QApplication desktop file name to `linuxshowplayer` during startup.

This keeps the existing application name unchanged and does not add the optional CLI override proposed in the issue.

Validation:
- `git diff --check`
- `python3 -m py_compile lisp/main.py`

PyQt5 is not installed in the local validation environment, so no GUI runtime smoke was performed.